### PR TITLE
Swap windowWidth and windowHeight params for DevelopmentEntryPoint

### DIFF
--- a/hot-reload-runtime-api/src/commonMain/kotlin/org/jetbrains/compose/reload/DevelopmentEntryPoint.kt
+++ b/hot-reload-runtime-api/src/commonMain/kotlin/org/jetbrains/compose/reload/DevelopmentEntryPoint.kt
@@ -6,6 +6,6 @@ import androidx.compose.runtime.Composable
 public expect fun DevelopmentEntryPoint(child: @Composable () -> Unit)
 
 public annotation class DevelopmentEntryPoint(
-    val windowHeight: Int = 1024,
     val windowWidth: Int = 576,
+    val windowHeight: Int = 1024,
 )


### PR DESCRIPTION
Follow the conventional (x,y) or (width,height) ordering