### PR TITLE
Add more IJP-related packages to ignores

### DIFF
--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ignore.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ignore.kt
@@ -7,10 +7,14 @@ internal fun isIgnoredClassId(classId: String): Boolean = with(classId) {
             startsWith("javax/") ||
             startsWith("java/") ||
             startsWith("jdk/") ||
+            startsWith("com/sun/") ||
+            startsWith("io/netty/") ||
             startsWith("sun/") ||
             startsWith("kotlin/") ||
             startsWith("kotlinx/") ||
             startsWith("androidx/") ||
             startsWith("org/jetbrains/skia/") ||
-            startsWith("org/jetbrains/skiko/")
+            startsWith("org/jetbrains/skiko/") ||
+            startsWith("com/intellij") ||
+            startsWith("com/jetbrains")
 }


### PR DESCRIPTION
This PR adds a few more exclusions to the ignores list, so hot reload can skip a few more unchangeable classes from the JDK and IJP