### PR TITLE
Clean dev tooling console

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/DevToolingConsole.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/DevToolingConsole.kt
@@ -5,33 +5,18 @@
 
 package org.jetbrains.compose.reload.jvm.tooling
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
-import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,10 +24,11 @@ import io.sellmair.evas.compose.composeValue
 import org.jetbrains.compose.reload.jvm.tooling.states.ConsoleLogState
 
 @Composable
-fun DevToolingConsole(tag: String, modifier: Modifier) {
+fun DevToolingConsole(tag: String, modifier: Modifier = Modifier) {
     val listState = rememberLazyListState()
-    var isExpanded by remember { mutableStateOf(true) }
     val logState = ConsoleLogState.Key(tag).composeValue()
+    val scroll = rememberScrollState(0)
+
 
     LaunchedEffect(logState) {
         if (logState.logs.isEmpty()) return@LaunchedEffect
@@ -50,46 +36,14 @@ fun DevToolingConsole(tag: String, modifier: Modifier) {
     }
 
     Column(modifier = modifier) {
-        ExpandButton(
-            isExpanded = isExpanded,
-            onClick = { expanded -> isExpanded = expanded },
-        ) {
-            Text(tag, fontSize = 16.sp, fontWeight = FontWeight.Bold)
-        }
-
-        AnimatedVisibility(isExpanded) {
-            Card(Modifier.padding(8.dp).fillMaxWidth()) {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.padding(8.dp).wrapContentHeight()
-                ) {
-                    items(logState.logs) { text ->
-                        Text(text, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
-                    }
-                }
+        Text(tag, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+        Card(Modifier.padding(vertical = 8.dp).fillMaxSize()) {
+            SelectionContainer {
+                Text(
+                    logState.logs.joinToString("\n"),
+                    modifier = Modifier.verticalScroll(scroll).padding(8.dp)
+                )
             }
         }
-    }
-}
-
-@Composable
-fun ExpandButton(
-    isExpanded: Boolean,
-    onClick: (expanded: Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    children: @Composable RowScope.() -> Unit
-) {
-    val rotation by animateFloatAsState(if (isExpanded) 0f else -90f)
-
-    Row(
-        modifier = modifier
-            .clickable(onClick = { onClick(!isExpanded) }),
-        verticalAlignment = CenterVertically,
-    ) {
-        Icon(
-            Icons.Default.ArrowDropDown, contentDescription = null,
-            modifier = Modifier.rotate(rotation),
-        )
-        children()
     }
 }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/DevToolingWidget.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/DevToolingWidget.kt
@@ -21,9 +21,6 @@ internal fun DevToolingWidget(modifier: Modifier = Modifier) {
     ) {
         DevToolingToolbar()
 
-        val consoleWeight = Modifier.weight(1f, fill = false)
-        DevToolingConsole(LogMessage.TAG_COMPILER, consoleWeight)
-        DevToolingConsole(LogMessage.TAG_AGENT, consoleWeight)
-        DevToolingConsole(LogMessage.TAG_RUNTIME, consoleWeight)
+        DevToolingConsole(LogMessage.TAG_COMPILER, Modifier.fillMaxSize())
     }
 }


### PR DESCRIPTION
Remove the Agent and Rumtime log consoled as they were not being used anymore.

Expand the Compiler Console to fill available size and made the log text selectable to be able to copy it easily.