### PR TITLE
Fix sidecar window failing to expand on Linux

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/OperatingSystem.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/OperatingSystem.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.jvm.tooling
+
+val isLinux by lazy {
+    "linux" in System.getProperty("os.name").lowercase()
+}

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarWindow.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarWindow.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.delay
 import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.createLogger
 import org.jetbrains.compose.reload.jvm.tooling.invokeWhenMessageReceived
+import org.jetbrains.compose.reload.jvm.tooling.isLinux
 import org.jetbrains.compose.reload.jvm.tooling.orchestration
 import org.jetbrains.compose.reload.jvm.tooling.theme.DtColors
 import org.jetbrains.compose.reload.jvm.tooling.widgets.DtButton
@@ -102,6 +103,9 @@ fun DtSidecarWindow(
     LaunchedEffect(sideCarWidth) {
         xAnimatable.snapTo(targetX.value)
         yAnimatable.snapTo(targetY.value)
+        if (isLinux) {
+            orchestration.sendMessage(OrchestrationMessage.UpdateSidecarWindowStateRequest(windowId))
+        }
     }
 
     val sidecarWindowState = DialogState(

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/states/WindowsState.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/states/WindowsState.kt
@@ -51,5 +51,16 @@ fun CoroutineScope.launchWindowsState() = launchState(WindowsState.Key) {
             windows.remove(message.windowId)
             update()
         }
+
+        if (message is OrchestrationMessage.UpdateSidecarWindowStateRequest) {
+            windows[message.windowId]?.let { existing ->
+                windows[message.windowId] = WindowState(
+                    placement = WindowPlacement.Floating,
+                    position = existing.position,
+                    size = existing.size
+                )
+                update()
+            }
+        }
     }
 }

--- a/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationMessage.kt
+++ b/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationMessage.kt
@@ -111,6 +111,13 @@ public sealed class OrchestrationMessage : Serializable {
     ) : OrchestrationMessage()
 
     /**
+     * Requests the sidecar window to recompose with a new copy of the window state
+     */
+    public data class UpdateSidecarWindowStateRequest(
+        val windowId: WindowId,
+    ) : OrchestrationMessage()
+
+    /**
      * Simple message that can be passed across the whole orchestration:
      * Can be used for very important log messages, or for testing.
      */


### PR DESCRIPTION
On Linux, the tooling window fails to expand when the icon is clicked, until it's next recomposed with a new `WindowState`. This PR forces the update which fixes the problem. The change is only applied on Linux.

I am not sure what's the underlying reason for this being required (or not required on other systems), there might be a better solution if the reason is found.