### PR TITLE
Removed window transparency on Linux to workaround skiko bug

### DIFF
--- a/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/devTools.kt
+++ b/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/devTools.kt
@@ -38,6 +38,7 @@ internal fun launchDevtoolsApplication() {
         java, "-cp", classpath.joinToString(File.pathSeparator),
         "-D${HotReloadProperty.OrchestrationPort.key}=${orchestration.port}",
         "-D${HotReloadProperty.GradleBuildContinuous.key}=${HotReloadEnvironment.gradleBuildContinuous}",
+        "-D${HotReloadProperty.DevToolsTransparencyEnabled.key}=${HotReloadEnvironment.devToolsTransparencyEnabled}",
         "-Dapple.awt.UIElement=true",
         "org.jetbrains.compose.reload.jvm.tooling.Main",
         "--applicationCommand=$java",

--- a/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/environment.kt
+++ b/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/environment.kt
@@ -30,6 +30,7 @@ public enum class HotReloadProperty(public val key: String) {
 
     DevToolsEnabled("compose.reload.devToolsEnabled"),
     DevToolsClasspath("compose.reload.devToolsClasspath"),
+    DevToolsTransparencyEnabled("compose.reload.devToolsTransparencyEnabled"),
 
     /**
      * Note: Expected as an environment variable, as this is expected to be transitively available
@@ -84,6 +85,7 @@ public object HotReloadEnvironment {
 
     public val devToolsEnabled: Boolean = systemBoolean(HotReloadProperty.DevToolsEnabled, true)
     public val devToolsClasspath: List<Path>? = systemFiles(HotReloadProperty.DevToolsClasspath)
+    public val devToolsTransparencyEnabled: Boolean = systemBoolean(HotReloadProperty.DevToolsTransparencyEnabled, true)
 
     /**
      * @see HotReloadProperty.IntelliJDebuggerDispatchPort

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/OperatingSystem.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/OperatingSystem.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.jvm.tooling
+
+val isLinux by lazy {
+    "linux" in System.getProperty("os.name").lowercase()
+}

--- a/hot-reload-gradle-plugin/api/hot-reload-gradle-plugin.api
+++ b/hot-reload-gradle-plugin/api/hot-reload-gradle-plugin.api
@@ -12,6 +12,7 @@ public abstract interface class org/jetbrains/compose/reload/ComposeHotReloadArg
 	public abstract fun setAgentJar (Lorg/gradle/api/file/FileCollection;)V
 	public abstract fun setDevToolsClasspath (Lorg/gradle/api/file/FileCollection;)V
 	public abstract fun setDevToolsEnabled (Lorg/gradle/api/provider/Provider;)V
+	public abstract fun setDevToolsTransparencyEnabled (Lorg/gradle/api/provider/Provider;)V
 	public abstract fun setHotClasspath (Lorg/gradle/api/file/FileCollection;)V
 	public abstract fun setIsHeadless (Lorg/gradle/api/provider/Provider;)V
 	public abstract fun setPidFile (Lorg/gradle/api/provider/Provider;)V

--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/arguments.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/arguments.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
- * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 @file:JvmName("ComposeHotReloadArgumentsKt")
 
@@ -28,6 +28,7 @@ sealed interface ComposeHotReloadArgumentsBuilder {
     fun setPidFile(file: Provider<File>)
     fun setDevToolsEnabled(enabled: Provider<Boolean>)
     fun setDevToolsClasspath(files: FileCollection)
+    fun setDevToolsTransparencyEnabled(enabled: Provider<Boolean>)
     fun setReloadTaskName(name: Provider<String>)
     fun setReloadTaskName(name: String)
     fun isRecompileContinuous(isRecompileContinuous: Provider<Boolean>)
@@ -63,6 +64,9 @@ private class ComposeHotReloadArgumentsBuilderImpl(
     private val devToolsEnabled: Property<Boolean> = project.objects.property(Boolean::class.java)
         .value(project.isDevToolsEnabled)
 
+    private val devToolsTransparencyEnabled: Property<Boolean> = project.objects.property(Boolean::class.java)
+        .value(project.isDevToolsTransparencyEnabled)
+
     private val reloadTaskName: Property<String> = project.objects.property(String::class.java)
 
     private val isRecompileContinues: Property<Boolean> = project.objects.property(Boolean::class.java)
@@ -93,6 +97,10 @@ private class ComposeHotReloadArgumentsBuilderImpl(
         devToolsClasspath = files
     }
 
+    override fun setDevToolsTransparencyEnabled(enabled: Provider<Boolean>) {
+        devToolsEnabled.set(enabled)
+    }
+
     override fun setReloadTaskName(name: Provider<String>) {
         reloadTaskName.set(name)
     }
@@ -117,6 +125,7 @@ private class ComposeHotReloadArgumentsBuilderImpl(
             pidFile = pidFile,
             devToolsClasspath = devToolsClasspath,
             devToolsEnabled = devToolsEnabled,
+            devToolsTransparencyEnabled = devToolsTransparencyEnabled,
             reloadTaskName = reloadTaskName,
             isRecompileContinues = isRecompileContinues,
             orchestrationPort = project.orchestrationPort,
@@ -135,6 +144,7 @@ private class ComposeHotReloadArgumentsImpl(
     private val pidFile: Provider<File>,
     private val devToolsClasspath: FileCollection,
     private val devToolsEnabled: Provider<Boolean>,
+    private val devToolsTransparencyEnabled: Provider<Boolean>,
     private val reloadTaskName: Provider<String>,
     private val isRecompileContinues: Provider<Boolean>,
     private val orchestrationPort: Provider<Int>
@@ -199,6 +209,7 @@ private class ComposeHotReloadArgumentsImpl(
 
         if (isDevToolsEnabled) {
             add("-D${HotReloadProperty.DevToolsClasspath.key}=${devToolsClasspath.asPath}")
+            add("-D${HotReloadProperty.DevToolsTransparencyEnabled.key}=${devToolsTransparencyEnabled.orNull ?: true}")
         }
 
         /* Provide "recompiler" properties */

--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/properties.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/properties.kt
@@ -8,12 +8,18 @@ package org.jetbrains.compose.reload
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.compose.reload.core.HotReloadProperty
+import org.jetbrains.kotlin.konan.target.HostManager
 
 internal val Project.isHeadless: Provider<Boolean>
     get() = providers.gradleProperty(HotReloadProperty.IsHeadless.key).map { raw -> raw.toBoolean() }
 
 internal val Project.isDevToolsEnabled: Provider<Boolean>
     get() = providers.gradleProperty(HotReloadProperty.DevToolsEnabled.key).map { raw -> raw.toBoolean() }
+
+internal val Project.isDevToolsTransparencyEnabled: Provider<Boolean>
+    get() = providers.gradleProperty(HotReloadProperty.DevToolsTransparencyEnabled.key).map(String?::toBoolean)
+        .orElse(providers.systemProperty(HotReloadProperty.DevToolsTransparencyEnabled.key).map(String?::toBoolean))
+        .orElse(!HostManager.hostIsLinux)
 
 internal val Project.isRecompileContinuous: Provider<Boolean>
     get() = providers.gradleProperty("compose.build.continuous").map { raw -> raw.toBoolean() }


### PR DESCRIPTION
On Linux, transparent windows cannot be used as they break hardware accelerated rendering due to a bug in skiko: https://youtrack.jetbrains.com/issue/CMP-5957/Transparent-windows-break-hardware-acceleration-on-Linux

This PR disables window transparency on the sidecar window on Linux.
- Sidecar window no longer has rounded corners
- The expanding/collapsing animation is removed, as it cannot work without the window being transparent
- The `DtReloadStatusBanner` is removed, as it also relies on the transparency. The functionality of seeing the reload status is still available, as even in the collapsed state it's visible on the icon.

These changes only apply on Linux. When running on macOS and Windows, nothing is affected. This does unfortunately make the tooling window look less attractive, ideally the changes can be reverted when the skiko bug is fixed.