### PR TITLE
Extract interfaces for Gradle model entities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 version=1.0.0-alpha06-102
 # Version used to bootstrap the repo
 # Mostly the same as the 'version'.
-bootstrap.version=1.0.0-alpha06-100
+bootstrap.version=1.0.0-alpha06-102
 compose.reload.autoRuntimeDependenciesEnabled=false
 ############
 # Gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ############
 # Version used for publications
 # Will be bumped only right before release
-version=1.0.0-alpha06-100
+version=1.0.0-alpha06-102
 # Version used to bootstrap the repo
 # Mostly the same as the 'version'.
 bootstrap.version=1.0.0-alpha06-100

--- a/hot-reload-gradle-idea/src/main/kotlin/org/jetbrains/compose/reload/gradle/idea/model.kt
+++ b/hot-reload-gradle-idea/src/main/kotlin/org/jetbrains/compose/reload/gradle/idea/model.kt
@@ -35,6 +35,7 @@ private val json = Json {
     ignoreUnknownKeys = true
     isLenient = true
     coerceInputValues = true
+    encodeDefaults = true
     serializersModule = module
 }
 
@@ -42,6 +43,7 @@ private val prettyJson = Json {
     ignoreUnknownKeys = true
     isLenient = true
     coerceInputValues = true
+    encodeDefaults = true
     prettyPrint = true
     serializersModule = module
 }

--- a/hot-reload-gradle-idea/src/main/kotlin/org/jetbrains/compose/reload/gradle/idea/model.kt
+++ b/hot-reload-gradle-idea/src/main/kotlin/org/jetbrains/compose/reload/gradle/idea/model.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.compose.reload.gradle.idea
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -17,8 +16,6 @@ import kotlin.io.path.Path
 import kotlin.io.path.pathString
 
 private val module = SerializersModule {
-    contextual(Path::class, PathSerializer())
-
     polymorphic(
         baseClass = IdeaComposeHotRunTask::class,
         actualClass = IdeaComposeHotRunTaskImpl::class,
@@ -128,7 +125,8 @@ internal data class IdeaComposeHotRunTaskImpl(
     override val targetName: String? = null,
     override val compilationName: String? = null,
     override val sourceSets: List<String> = emptyList(),
-    override val argFile: @Contextual Path? = null,
+    @Serializable(with = PathSerializer::class)
+    override val argFile: Path? = null,
     override val argFileTaskName: String? = null,
 ) : IdeaComposeHotRunTask
 

--- a/hot-reload-gradle-idea/src/test/kotlin/org/jetbrains/compose/reload/gradle/idea/tests/SerializationTest.kt
+++ b/hot-reload-gradle-idea/src/test/kotlin/org/jetbrains/compose/reload/gradle/idea/tests/SerializationTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.compose.reload.gradle.idea.tests
 
 import org.jetbrains.compose.reload.gradle.idea.IdeaComposeHotReloadModel
+import org.jetbrains.compose.reload.gradle.idea.IdeaComposeHotReloadModelImpl
 import org.jetbrains.compose.reload.gradle.idea.IdeaComposeHotRunTask
 import java.io.ByteArrayOutputStream
 import java.io.ObjectInputStream
@@ -35,7 +36,7 @@ class SerializationTest {
 
     @Test
     fun `test - malformed json - is lenient`() {
-        val model = IdeaComposeHotReloadModel.Surrogate(
+        val model = IdeaComposeHotReloadModelImpl.Surrogate(
             """
             {
                 "unknownField": "myValue", 

--- a/hot-reload-test/sample/build.gradle.kts
+++ b/hot-reload-test/sample/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
     jvm()
 
     sourceSets.jvmMain.dependencies {
-        implementation("org.jetbrains.compose.hot-reload:runtime-api:1.0.0-alpha06-100")
+        implementation("org.jetbrains.compose.hot-reload:runtime-api:1.0.0-alpha06-102")
         implementation(compose.runtime)
     }
 

--- a/hot-reload-test/sample/settings.gradle.kts
+++ b/hot-reload-test/sample/settings.gradle.kts
@@ -5,8 +5,8 @@
 
 pluginManagement {
     plugins {
-        id("org.jetbrains.compose.hot-reload") version "1.0.0-alpha06-100"
-        id("org.jetbrains.compose.hot-reload.test") version "1.0.0-alpha06-100"
+        id("org.jetbrains.compose.hot-reload") version "1.0.0-alpha06-102"
+        id("org.jetbrains.compose.hot-reload.test") version "1.0.0-alpha06-102"
     }
 
     repositories {

--- a/samples/bytecode-analyzer/build.gradle.kts
+++ b/samples/bytecode-analyzer/build.gradle.kts
@@ -21,8 +21,8 @@ kotlin {
     }
 
     sourceSets.commonMain.dependencies {
-        implementation("org.jetbrains.compose.hot-reload:core:1.0.0-alpha06-100")
-        implementation("org.jetbrains.compose.hot-reload:analysis:1.0.0-alpha06-100")
+        implementation("org.jetbrains.compose.hot-reload:core:1.0.0-alpha06-102")
+        implementation("org.jetbrains.compose.hot-reload:analysis:1.0.0-alpha06-102")
 
         implementation("io.sellmair:evas:1.2.0")
         implementation("io.sellmair:evas-compose:1.2.0")

--- a/samples/bytecode-analyzer/settings.gradle.kts
+++ b/samples/bytecode-analyzer/settings.gradle.kts
@@ -5,7 +5,7 @@
 
 pluginManagement {
     plugins {
-        id("org.jetbrains.compose.hot-reload") version "1.0.0-alpha06-100"
+        id("org.jetbrains.compose.hot-reload") version "1.0.0-alpha06-102"
     }
 
     repositories {

--- a/samples/counter/settings.gradle.kts
+++ b/samples/counter/settings.gradle.kts
@@ -5,7 +5,7 @@
 
 pluginManagement {
     plugins {
-        id("org.jetbrains.compose.hot-reload") version "1.0.0-alpha06-100"
+        id("org.jetbrains.compose.hot-reload") version "1.0.0-alpha06-102"
     }
 
     repositories {


### PR DESCRIPTION
Extracts interfaces for Gradle model entities to avoid exceptions like
```
com.intellij.openapi.externalSystem.model.ExternalSystemException: org.jetbrains.compose.reload.gradle.idea.IdeaComposeHotReloadModel is not an interface
```
and suggest some improvements in serialisation stragegy