### PR TITLE
Option to always show the reload counter in dev tools

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtReloadCounterStatusItem.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtReloadCounterStatusItem.kt
@@ -5,10 +5,12 @@
 
 package org.jetbrains.compose.reload.jvm.tooling.sidecar
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import io.sellmair.evas.compose.composeValue
@@ -38,12 +40,18 @@ fun DtCollapsedReloadCounterStatusItem() {
     val state = ReloadCountState.composeValue()
     if (state.successfulReloads < 1) return
 
-    val defaultText = "⟳${state.successfulReloads}"
-    val defaultModifier = Modifier.tag(ReloadCounterText)
-    val (text, modifier) = when {
-        state.successfulReloads < 10 -> defaultText to defaultModifier
-        state.successfulReloads < 100 -> defaultText to defaultModifier.scale(0.9f)
-        else -> defaultText.drop(1) to defaultModifier.scale(0.7f)
+    val textScale = when {
+        state.successfulReloads < 10 -> 1.0f
+        state.successfulReloads < 100 -> 0.9f
+        else -> 0.7f
     }
-    DtText(text = text, modifier = modifier)
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.scale(textScale)
+    ) {
+        if (state.successfulReloads < 100) {
+            DtText("⟳", modifier = Modifier.scale(1.25f))
+        }
+        DtText(text = "${state.successfulReloads}", modifier = Modifier.tag(ReloadCounterText))
+    }
 }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtReloadCounterStatusItem.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtReloadCounterStatusItem.kt
@@ -10,16 +10,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.draw.scale
 import io.sellmair.evas.compose.composeValue
-import org.jetbrains.compose.reload.jvm.tooling.Tag
 import org.jetbrains.compose.reload.jvm.tooling.Tag.ReloadCounterText
 import org.jetbrains.compose.reload.jvm.tooling.states.ReloadCountState
 import org.jetbrains.compose.reload.jvm.tooling.tag
 import org.jetbrains.compose.reload.jvm.tooling.widgets.DtText
 
 @Composable
-fun DtReloadCounterStatusItem() {
+fun DtExpandedReloadCounterStatusItem() {
     val state = ReloadCountState.composeValue()
 
     if (state.successfulReloads > 0) {
@@ -32,4 +31,19 @@ fun DtReloadCounterStatusItem() {
             }
         )
     }
+}
+
+@Composable
+fun DtCollapsedReloadCounterStatusItem() {
+    val state = ReloadCountState.composeValue()
+    if (state.successfulReloads < 1) return
+
+    val defaultText = "⟳${state.successfulReloads}"
+    val defaultModifier = Modifier.tag(ReloadCounterText)
+    val (text, modifier) = when {
+        state.successfulReloads < 10 -> defaultText to defaultModifier
+        state.successfulReloads < 100 -> defaultText to defaultModifier.scale(0.9f)
+        else -> defaultText.drop(1) to defaultModifier.scale(0.7f)
+    }
+    DtText(text = text, modifier = modifier)
 }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtReloadCounterStatusItem.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtReloadCounterStatusItem.kt
@@ -5,7 +5,9 @@
 
 package org.jetbrains.compose.reload.jvm.tooling.sidecar
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
@@ -13,10 +15,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.unit.dp
 import io.sellmair.evas.compose.composeValue
 import org.jetbrains.compose.reload.jvm.tooling.Tag.ReloadCounterText
 import org.jetbrains.compose.reload.jvm.tooling.states.ReloadCountState
 import org.jetbrains.compose.reload.jvm.tooling.tag
+import org.jetbrains.compose.reload.jvm.tooling.theme.DtTextStyles
 import org.jetbrains.compose.reload.jvm.tooling.widgets.DtText
 
 @Composable
@@ -40,18 +44,23 @@ fun DtCollapsedReloadCounterStatusItem() {
     val state = ReloadCountState.composeValue()
     if (state.successfulReloads < 1) return
 
-    val textScale = when {
+    val scale = when {
         state.successfulReloads < 10 -> 1.0f
-        state.successfulReloads < 100 -> 0.9f
-        else -> 0.7f
+        else -> 0.9f
     }
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.scale(textScale)
+        modifier = Modifier.scale(scale)
     ) {
         if (state.successfulReloads < 100) {
-            DtText("⟳", modifier = Modifier.scale(1.25f))
+            Box(modifier = Modifier.size(10.dp)) {
+                Icon(Icons.Default.Refresh, "Reload")
+            }
         }
-        DtText(text = "${state.successfulReloads}", modifier = Modifier.tag(ReloadCounterText))
+        DtText(
+            text = "${state.successfulReloads}",
+            modifier = Modifier.tag(ReloadCounterText),
+            style = DtTextStyles.smallSemiBold
+        )
     }
 }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarStatusSection.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarStatusSection.kt
@@ -39,7 +39,7 @@ fun DtSidecarStatusSection() {
                     .dtVerticalPadding()
             ) {
                 DtReloadStatusItem()
-                DtReloadCounterStatusItem()
+                DtExpandedReloadCounterStatusItem()
                 DtMissingJbrStatusItem()
                 DtRuntimeErrorStatusItem()
             }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarWindow.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarWindow.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.WindowState
+import org.jetbrains.compose.reload.core.HotReloadEnvironment.devToolsAlwaysShowReloadCounter
 import org.jetbrains.compose.reload.core.HotReloadEnvironment.devToolsTransparencyEnabled
 import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.createLogger
@@ -129,14 +130,22 @@ fun DtSidecarWindowContent(
                         exit = if (devToolsTransparencyEnabled) fadeOut(tween(50)) else ExitTransition.None
                     ),
                 ) {
-                    DtComposeLogo(
-                        Modifier.size(28.dp).padding(4.dp),
-                        tint = animateReloadStatusColor(
-                            idleColor = composeLogoColor,
-                            reloadingColor = DtColors.statusColorOrange2
-                        ).value
-                    )
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        DtComposeLogo(
+                            Modifier.size(28.dp).padding(4.dp),
+                            tint = animateReloadStatusColor(
+                                idleColor = composeLogoColor,
+                                reloadingColor = DtColors.statusColorOrange2
+                            ).value
+                        )
+                        if (devToolsAlwaysShowReloadCounter) {
+                            DtCollapsedReloadCounterStatusItem()
+                        }
+                    }
                 }
+
 
             } else {
                 Column {

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarWindow.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/sidecar/DtSidecarWindow.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.WindowState
-import org.jetbrains.compose.reload.core.HotReloadEnvironment.devToolsAlwaysShowReloadCounter
 import org.jetbrains.compose.reload.core.HotReloadEnvironment.devToolsTransparencyEnabled
 import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.createLogger
@@ -140,9 +139,7 @@ fun DtSidecarWindowContent(
                                 reloadingColor = DtColors.statusColorOrange2
                             ).value
                         )
-                        if (devToolsAlwaysShowReloadCounter) {
-                            DtCollapsedReloadCounterStatusItem()
-                        }
+                        DtCollapsedReloadCounterStatusItem()
                     }
                 }
 

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/theme/DtTextStyles.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/reload/jvm/tooling/theme/DtTextStyles.kt
@@ -37,4 +37,9 @@ object DtTextStyles {
         fontFamily = FontFamily.Monospace,
         fontWeight = FontWeight.Normal,
     )
+
+    val smallSemiBold = small.copy(
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold
+    )
 }

--- a/properties.yaml
+++ b/properties.yaml
@@ -159,6 +159,15 @@ DevToolsTransparencyEnabled:
     Some platforms might not be able to render transparency correctly (e.g. some linux environments).
     This property will allow such platforms to disable/enable transparency
 
+DevToolsAlwaysShowReloadCounter:
+  key: compose.reload.devToolsAlwaysShowReloadCounter
+  type: boolean
+  default: "false"
+  defaultIsExpression: false
+  target: [ application, build, devtools ]
+  documentation: |
+    When set to `true` dev tools will always show the current reload counter, even when the side bar is not expanded.
+
 IntelliJDebuggerDispatchPort:
   key: compose.reload.idea.debugger.dispatch.port
   type: int

--- a/properties.yaml
+++ b/properties.yaml
@@ -159,15 +159,6 @@ DevToolsTransparencyEnabled:
     Some platforms might not be able to render transparency correctly (e.g. some linux environments).
     This property will allow such platforms to disable/enable transparency
 
-DevToolsAlwaysShowReloadCounter:
-  key: compose.reload.devToolsAlwaysShowReloadCounter
-  type: boolean
-  default: "false"
-  defaultIsExpression: false
-  target: [ application, build, devtools ]
-  documentation: |
-    When set to `true` dev tools will always show the current reload counter, even when the side bar is not expanded.
-
 IntelliJDebuggerDispatchPort:
   key: compose.reload.idea.debugger.dispatch.port
   type: int


### PR DESCRIPTION
Simple implementation that allows to always show the reload counter. Waiting for feedback on UI   😃. Also, I'm not sure if it should be enabled by default.