### PR TITLE
Fix reloading on compose 1.9.0+: correctly search for FunctionKeyMeta…

### DIFF
--- a/.teamcity/testDimensions.json
+++ b/.teamcity/testDimensions.json
@@ -23,8 +23,11 @@
   ],
   "compose": [
     {
-      "version": "1.8.0",
+      "version": "1.8.1",
       "isDefault": true
+    },
+    {
+      "version": "1.9.0-alpha02"
     }
   ]
 }

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/MethodType.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/MethodType.kt
@@ -5,10 +5,8 @@
 
 package org.jetbrains.compose.reload.analysis
 
-import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
-import kotlin.collections.orEmpty
 
 internal fun MethodType(methodNode: MethodNode): MethodType = when {
     methodNode.instructions.filterIsInstance<MethodInsnNode>()
@@ -55,9 +53,3 @@ private val COMPOSE_FUNCTION_ANNOTATIONS = setOf(
     Ids.Composable.classId,
     Ids.FunctionKeyMeta.classId,
 )
-
-private val MethodNode.allAnnotations: List<AnnotationNode>
-    get() = buildList {
-        addAll(visibleAnnotations.orEmpty())
-        addAll(invisibleAnnotations.orEmpty())
-    }

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/asmUtils.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/asmUtils.kt
@@ -13,6 +13,7 @@ import org.objectweb.asm.Handle
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Opcodes.ASM9
 import org.objectweb.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldInsnNode
 import org.objectweb.asm.tree.FieldNode
@@ -38,7 +39,7 @@ internal fun AbstractInsnNode.intValueOrNull(): Int? {
 }
 
 internal fun MethodNode.readFunctionKeyMetaAnnotation(): ComposeGroupKey? {
-    val functionKey = visibleAnnotations.orEmpty().find { annotationNode ->
+    val functionKey = allAnnotations.find { annotationNode ->
         annotationNode.desc == Ids.FunctionKeyMeta.classId.descriptor
     }?.values?.zipWithNext()?.find { (name, _) -> name == "key" }?.second as? Int
 
@@ -102,3 +103,9 @@ internal fun FieldId(classNode: ClassNode, fieldNode: FieldNode): FieldId = Fiel
     fieldName = fieldNode.name,
     fieldDescriptor = fieldNode.desc
 )
+
+internal val MethodNode.allAnnotations: List<AnnotationNode>
+    get() = buildList {
+        addAll(visibleAnnotations.orEmpty())
+        addAll(invisibleAnnotations.orEmpty())
+    }


### PR DESCRIPTION
After our change to `FunctionKeyMeta` annotation, in newer compose versions it will appear in `MethodNode.invisibleAnnotations`, instead of `MethodNode.visibleAnnotations`. So we can just check for both of them.

Alternatively, we can check for the current CMP version and decide which list to check, but I don't think it makes sense currently. @sellmair WDYT?