### PR TITLE
#242: Support 1.9.0-alpha03 'SwingWindow' and 'SwingDialog'

### DIFF
--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ids.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ids.kt
@@ -106,6 +106,18 @@ object Ids {
         )
     }
 
+    object DialogDesktopKt {
+        val classId = ClassId("androidx/compose/ui/window/Dialog_desktopKt")
+    }
+
+    object SwingWindowDesktopKt {
+        val classId = ClassId("androidx/compose/ui/awt/SwingWindow_desktopKt")
+    }
+
+    object SwingDialogDesktopKt {
+        val classId = ClassId("androidx/compose/ui/awt/SwingDialog_desktopKt")
+    }
+
     object ApplicationDesktopKt {
         val classId = ClassId("androidx/compose/ui/window/Application_desktopKt")
 
@@ -140,6 +152,22 @@ object Ids {
 
     object ComposeWindow {
         val classId = ClassId("androidx/compose/ui/awt/ComposeWindow")
+
+        val setContent_1 = MethodId(
+            classId,
+            methodName = "setContent",
+            methodDescriptor = "(Lkotlin/jvm/functions/Function3)V"
+        )
+
+        val setContent_3 = MethodId(
+            classId,
+            methodName = "setContent",
+            methodDescriptor = "(Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V"
+        )
+    }
+
+    object ComposeDialog {
+        val classId = ClassId("androidx/compose/ui/awt/ComposeDialog")
 
         val setContent_1 = MethodId(
             classId,

--- a/hot-reload-runtime-jvm/api/hot-reload-runtime-jvm.api
+++ b/hot-reload-runtime-jvm/api/hot-reload-runtime-jvm.api
@@ -1,5 +1,7 @@
 public final class org/jetbrains/compose/reload/jvm/JvmDevelopmentEntryPoint {
 	public static final fun DevelopmentEntryPoint (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun setContent (Landroidx/compose/ui/awt/ComposeDialog;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public static final fun setContent (Landroidx/compose/ui/awt/ComposeDialog;Lkotlin/jvm/functions/Function3;)V
 	public static final fun setContent (Landroidx/compose/ui/awt/ComposeWindow;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
 	public static final fun setContent (Landroidx/compose/ui/awt/ComposeWindow;Lkotlin/jvm/functions/Function3;)V
 }

--- a/hot-reload-runtime-jvm/src/dev/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
+++ b/hot-reload-runtime-jvm/src/dev/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.ComposeDialog
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.window.DialogWindowScope
 import androidx.compose.ui.window.FrameWindowScope
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.update
@@ -113,6 +115,34 @@ internal fun ComposeWindow.setContent(
 @PublishedApi
 internal fun ComposeWindow.setContent(
     content: @Composable FrameWindowScope.() -> Unit
+) {
+    setContent {
+        DevelopmentEntryPoint {
+            content()
+        }
+    }
+}
+
+@Suppress("unused", "EXTENSION_SHADOWED_BY_MEMBER") // used by instrumentation
+@OptIn(ExperimentalComposeUiApi::class)
+@PublishedApi
+internal fun ComposeDialog.setContent(
+    onPreviewKeyEvent: (KeyEvent) -> Boolean,
+    onKeyEvent: (KeyEvent) -> Boolean,
+    content: @Composable DialogWindowScope.() -> Unit
+) {
+    setContent(onPreviewKeyEvent = onPreviewKeyEvent, onKeyEvent = onKeyEvent) {
+        DevelopmentEntryPoint {
+            content()
+        }
+    }
+}
+
+@Suppress("unused", "EXTENSION_SHADOWED_BY_MEMBER") // used by instrumentation
+@OptIn(ExperimentalComposeUiApi::class)
+@PublishedApi
+internal fun ComposeDialog.setContent(
+    content: @Composable DialogWindowScope.() -> Unit
 ) {
     setContent {
         DevelopmentEntryPoint {

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
@@ -9,8 +9,10 @@ package org.jetbrains.compose.reload.jvm
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.ComposeDialog
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.window.DialogWindowScope
 import androidx.compose.ui.window.FrameWindowScope
 
 @Composable
@@ -46,3 +48,32 @@ internal fun ComposeWindow.setContent(
         }
     }
 }
+
+@Suppress("unused", "EXTENSION_SHADOWED_BY_MEMBER") // used by instrumentation
+@OptIn(ExperimentalComposeUiApi::class)
+@PublishedApi
+internal fun ComposeDialog.setContent(
+    onPreviewKeyEvent: (KeyEvent) -> Boolean,
+    onKeyEvent: (KeyEvent) -> Boolean,
+    content: @Composable DialogWindowScope.() -> Unit
+) {
+    setContent(onPreviewKeyEvent = onPreviewKeyEvent, onKeyEvent = onKeyEvent) {
+        DevelopmentEntryPoint {
+            content()
+        }
+    }
+}
+
+@Suppress("unused", "EXTENSION_SHADOWED_BY_MEMBER") // used by instrumentation
+@OptIn(ExperimentalComposeUiApi::class)
+@PublishedApi
+internal fun ComposeDialog.setContent(
+    content: @Composable DialogWindowScope.() -> Unit
+) {
+    setContent {
+        DevelopmentEntryPoint {
+            content()
+        }
+    }
+}
+

--- a/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/DevelopmentEntryPointIntegrationTest.kt
+++ b/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/DevelopmentEntryPointIntegrationTest.kt
@@ -21,29 +21,18 @@ import kotlin.test.fail
 class DevelopmentEntryPointIntegrationTest {
 
     /**
-     * This test, annoyingly, runs non-headless. This might also lead to CI agents not being
+     * These tests, annoyingly, run non-headless. This might also lead to CI agents not being
      * able to execute this test. A better test alternative would be nice.
      */
+
     @Headless(false)
     @HostIntegrationTest
     @HotReloadTest
     fun `test - singleWindowApplication`(
         fixture: HotReloadTestFixture
-    ) = fixture.runTest {
-        /*
-        This test does not run the underlying screenshot test application.
-        Therefore, we'll manually send back ACK messages
-         */
-        launchTask {
-            orchestration.messages.collect { message ->
-                if(message !is OrchestrationMessage.Ack) {
-                    orchestration send OrchestrationMessage.Ack(message.messageId)
-                }
-            }
-        }
-
-        val devtools = fixture.initialSourceCode(
-            """
+    ) = runDevelopmentEntryPointTest(
+        fixture,
+        """
             import androidx.compose.foundation.layout.*
             import androidx.compose.material3.*
             import androidx.compose.runtime.*
@@ -57,7 +46,75 @@ class DevelopmentEntryPointIntegrationTest {
                }
             }
             """.trimIndent()
-        ) {
+    )
+
+    @Headless(false)
+    @HostIntegrationTest
+    @HotReloadTest
+    fun `test - Window`(
+        fixture: HotReloadTestFixture
+    ) = runDevelopmentEntryPointTest(
+        fixture,
+        """
+            import androidx.compose.foundation.layout.*
+            import androidx.compose.material3.*
+            import androidx.compose.runtime.*
+            import androidx.compose.ui.unit.*
+            import androidx.compose.ui.window.*
+            import org.jetbrains.compose.reload.test.*
+            
+            fun main() {
+                application {
+                    Window(onCloseRequest = ::exitApplication) {
+                        Text("This is a *non headless* test window!")
+                    }
+                }
+            }
+            """.trimIndent()
+    )
+
+    @Headless(false)
+    @HostIntegrationTest
+    @HotReloadTest
+    fun `test - DialogWindow`(
+        fixture: HotReloadTestFixture
+    ) = runDevelopmentEntryPointTest(
+        fixture,
+        """
+            import androidx.compose.foundation.layout.*
+            import androidx.compose.material3.*
+            import androidx.compose.runtime.*
+            import androidx.compose.ui.unit.*
+            import androidx.compose.ui.window.*
+            import org.jetbrains.compose.reload.test.*
+            
+            fun main() {
+                application {
+                    DialogWindow(onCloseRequest = ::exitApplication) {
+                        Text("This is a *non headless* test window!")
+                    }
+                }
+            }
+            """.trimIndent()
+    )
+
+    private fun runDevelopmentEntryPointTest(
+        fixture: HotReloadTestFixture,
+        content: String,
+    ) = fixture.runTest {
+        /*
+        This test does not run the underlying screenshot test application.
+        Therefore, we'll manually send back ACK messages
+         */
+        launchTask {
+            orchestration.messages.collect { message ->
+                if (message !is OrchestrationMessage.Ack) {
+                    orchestration send OrchestrationMessage.Ack(message.messageId)
+                }
+            }
+        }
+
+        val devtools = fixture.initialSourceCode(content) {
             skipToMessage<ClientConnected> { client -> client.clientRole == Tooling }.apply {
                 skipToMessage<ApplicationWindowPositioned>("Waiting for 'WindowPositioned' message")
             }


### PR DESCRIPTION
* Support new 'SwingWindow' and 'SwingDialog' from CMP 1.9.0-alpha03
* Support dialog windows for previous versions of CMP