### PR TITLE
Rollback "Allow subprocess debugging when launching any app with Hot Reload"

### DIFF
--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotRunTasks.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotRunTasks.kt
@@ -109,9 +109,9 @@ internal fun JavaExec.configureJavaExecTaskForHotReload(compilation: Provider<Ko
     Further, project-specific capabilities such as logging or extended debugging support below
     */
 
-    project.intellijDebuggerDispatchPort.orNull?.let { debuggerDispatchPort ->
-        systemProperty(HotReloadProperty.IntelliJDebuggerDispatchPort.key, debuggerDispatchPort)
-    }
+//    project.intellijDebuggerDispatchPort.orNull?.let { debuggerDispatchPort ->
+//        systemProperty(HotReloadProperty.IntelliJDebuggerDispatchPort.key, debuggerDispatchPort)
+//    }
 
     val intellijDebuggerDispatchPort = project
         .composeReloadIntelliJDebuggerDispatchPortProvider.orNull


### PR DESCRIPTION
#282 is seemingly caused by the fact that currently IntelliJ only supports single debugger connection per launched app. With subprocess debugging enabled, child processes (namely, Compose Hot Reload Dev Tools process) intercept the debugger. Thus, the debugging of the main user app does not work.

Fix: rollback support of subprocess debugging for now