### PR TITLE
CoroutinesTest.test - switching threads: increase timeout from 5 to 10 seconds

### DIFF
--- a/hot-reload-core/src/test/kotlin/CoroutinesTest.kt
+++ b/hot-reload-core/src/test/kotlin/CoroutinesTest.kt
@@ -1,4 +1,3 @@
-import org.jetbrains.compose.reload.core.Os
 import org.jetbrains.compose.reload.core.StoppedException
 import org.jetbrains.compose.reload.core.Task
 import org.jetbrains.compose.reload.core.WorkerThread
@@ -11,7 +10,6 @@ import org.jetbrains.compose.reload.core.isFailure
 import org.jetbrains.compose.reload.core.launchTask
 import org.jetbrains.compose.reload.core.reloadMainThread
 import org.jetbrains.compose.reload.core.withThread
-import org.junit.jupiter.api.Assumptions
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -63,11 +61,6 @@ class CoroutinesTest {
 
     @Test
     fun `test - switching threads`() {
-        Assumptions.assumeTrue(
-            Os.current() != Os.Windows,
-            "https://github.com/JetBrains/compose-hot-reload/issues/262"
-        )
-
         val threads = launchTask("test") {
             val threads = mutableListOf<Thread>()
             threads += Thread.currentThread()
@@ -91,7 +84,7 @@ class CoroutinesTest {
 
         assertEquals(
             listOf(reloadMainThread.name, "w1", "w2", reloadMainThread.name),
-            threads.value.getBlocking(5.seconds).getOrThrow().map { it.name }
+            threads.value.getBlocking(10.seconds).getOrThrow().map { it.name }
         )
     }
 


### PR DESCRIPTION
After running the tests 10+ times, the issue is not reproduced