### PR TITLE
#300: Improve DevTools window when transparency is disabled

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtAnimatedWindow.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtAnimatedWindow.kt
@@ -32,6 +32,7 @@ import org.jetbrains.compose.devtools.theme.DtShapes
 import org.jetbrains.compose.devtools.theme.DtTitles.DEV_TOOLS
 import org.jetbrains.compose.devtools.widgets.animateReloadStatusBackground
 import org.jetbrains.compose.devtools.widgets.animatedReloadStatusBorder
+import org.jetbrains.compose.reload.core.HotReloadEnvironment.devToolsAnimationsEnabled
 import org.jetbrains.compose.reload.core.HotReloadEnvironment.devToolsTransparencyEnabled
 import org.jetbrains.compose.reload.core.Os
 import org.jetbrains.compose.reload.core.Try
@@ -53,7 +54,8 @@ import kotlin.time.Duration.Companion.milliseconds
 private val logger = createLogger()
 
 // animation time of window effects
-internal val animationDuration = 512.milliseconds
+internal val animationDuration =
+    if (devToolsAnimationsEnabled) 512.milliseconds else 10.milliseconds
 
 // check if transparency and opacity are supported
 private val transparencySupported = transparencySupported()
@@ -233,12 +235,16 @@ internal fun getSideCarWindowPosition(mainWindowPosition: WindowPosition, width:
 }
 
 internal fun getSideCarWindowSize(mainWindowSize: DpSize, isExpanded: Boolean): DpSize {
-    return DpSize(
-        width = if (isExpanded) 512.dp else 32.dp + 4.dp + (12.dp.takeIf { devToolsUseTransparency } ?: 0.dp),
-        height = if (isExpanded) maxOf(mainWindowSize.height, 512.dp)
-        else if (devToolsUseTransparency) maxOf(mainWindowSize.height, 512.dp) else 44.dp + 4.dp,
-    )
+    return when {
+        isExpanded -> DpSize(512.dp, maxOf(mainWindowSize.height, 512.dp))
+        else -> DpSize(
+            width = 32.dp + 4.dp + if (devToolsUseTransparency) 12.dp else 0.dp,
+            height = if (devToolsUseTransparency) maxOf(mainWindowSize.height, 512.dp)
+            else 44.dp + 4.dp + if (Os.current() == Os.Windows) 2.dp else 0.dp
+        )
+    }
 }
+
 
 internal operator fun Point.plus(other: Point): Point = Point(x + other.x, y + other.y)
 

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtAttachedSidecar.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtAttachedSidecar.kt
@@ -41,11 +41,16 @@ import org.jetbrains.compose.devtools.Tag
 import org.jetbrains.compose.devtools.tag
 import org.jetbrains.compose.devtools.theme.DtColors
 import org.jetbrains.compose.devtools.theme.DtPadding
+import org.jetbrains.compose.devtools.theme.DtShapes
 import org.jetbrains.compose.devtools.theme.DtTitles.COMPOSE_HOT_RELOAD_TITLE
 import org.jetbrains.compose.devtools.widgets.DtComposeLogo
 import org.jetbrains.compose.devtools.widgets.DtReloadStatusBanner
 import org.jetbrains.compose.devtools.widgets.animateReloadStatusColor
+import org.jetbrains.compose.reload.core.HotReloadEnvironment.devToolsAnimationsEnabled
 import org.jetbrains.compose.reload.core.WindowId
+
+private val cornerShape = if (devToolsUseTransparency) DtShapes.RoundedCornerShape else DtShapes.SquareCornerShape
+private val useAnimatedTransitions = devToolsUseTransparency && devToolsAnimationsEnabled
 
 @Composable
 fun DtAttachedSidecarWindow(
@@ -148,7 +153,7 @@ internal fun DtMinimizedSidecarWindowContent(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
-                .dtBackground()
+                .dtBackground(cornerShape)
                 .weight(1f, fill = false)
                 /* Hack for macOS to save from phantom clicks */
                 .onPointerEvent(PointerEventType.Enter) { inFocus = true }
@@ -165,7 +170,7 @@ internal fun DtMinimizedSidecarWindowContent(
                     reloadingColor = DtColors.statusColorOrange2
                 ).value
             )
-            DtMinimisedReloadCounterStatusItem()
+            DtMinimisedReloadCounterStatusItem(showDefaultValue = !devToolsUseTransparency)
         }
 
         if (devToolsUseTransparency) {
@@ -190,10 +195,10 @@ internal fun DtExpandedSidecarWindowContent(
         AnimatedContent(
             isExpanded,
             modifier = Modifier
-                .dtBackground()
+                .dtBackground(cornerShape)
                 .weight(1f, fill = false),
             transitionSpec = {
-                if (devToolsUseTransparency) {
+                if (useAnimatedTransitions) {
                     (fadeIn(animationSpec = tween(22, delayMillis = 128)) +
                         scaleIn(initialScale = 0.92f, animationSpec = tween(220, delayMillis = 128)))
                         .togetherWith(fadeOut(animationSpec = tween(90)))
@@ -207,8 +212,8 @@ internal fun DtExpandedSidecarWindowContent(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
                         .animateEnterExit(
-                            enter = if (devToolsUseTransparency) fadeIn(tween(220)) else EnterTransition.None,
-                            exit = if (devToolsUseTransparency) fadeOut(tween(50)) else ExitTransition.None
+                            enter = if (useAnimatedTransitions) fadeIn(tween(220)) else EnterTransition.None,
+                            exit = if (useAnimatedTransitions) fadeOut(tween(50)) else ExitTransition.None
                         )
                         .tag(Tag.ExpandMinimiseButton)
                         .clickable { isExpandedChanged(true) }
@@ -222,7 +227,7 @@ internal fun DtExpandedSidecarWindowContent(
                             reloadingColor = DtColors.statusColorOrange2
                         ).value
                     )
-                    DtMinimisedReloadCounterStatusItem()
+                    DtMinimisedReloadCounterStatusItem(showDefaultValue = !devToolsUseTransparency)
                 }
             } else {
                 // Expanded state - show the full UI

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtReloadCounterStatusItem.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtReloadCounterStatusItem.kt
@@ -51,7 +51,7 @@ fun DtExpandedReloadCounterStatusItem() {
 }
 
 @Composable
-fun DtMinimisedReloadCounterStatusItem() {
+fun DtMinimisedReloadCounterStatusItem(showDefaultValue: Boolean = false) {
     val buildSystemState = BuildSystemState.composeValue()
     val reloadState = ReloadState.composeValue()
     val countState = ReloadCountState.composeValue()
@@ -78,7 +78,7 @@ fun DtMinimisedReloadCounterStatusItem() {
             }
         }
         else -> {
-            if (countState.successfulReloads < 1) return
+            if (countState.successfulReloads < 1 && !showDefaultValue) return
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.scale(scale).horizontalScroll(rememberScrollState())

--- a/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/MinimisedSidecarUiTest.kt
+++ b/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/MinimisedSidecarUiTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onParent
 import org.jetbrains.compose.devtools.Tag
 import org.jetbrains.compose.devtools.sidecar.DtMinimizedSidecarWindowContent
+import org.jetbrains.compose.devtools.sidecar.devToolsUseTransparency
 import org.jetbrains.compose.devtools.states.BuildSystemState
 import org.jetbrains.compose.devtools.states.ReloadCountState
 import org.jetbrains.compose.devtools.states.ReloadState
@@ -47,7 +48,11 @@ class MinimisedSidecarUiTest : SidecarBodyUiTest() {
 
     @Test
     fun `test - reload counter`() = runSidecarUiTest {
-        onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertDoesNotExist()
+        if (devToolsUseTransparency) {
+            onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertDoesNotExist()
+        } else {
+            onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertTextContains("0", substring = true)
+        }
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(1) }
         onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertTextContains("1", substring = true)

--- a/properties.yaml
+++ b/properties.yaml
@@ -175,6 +175,15 @@ DevToolsDetached:
   documentation: |
     If enabled, dev tools window will be detached from the main application
 
+DevToolsAnimationsEnabled:
+  key: compose.reload.devToolsAnimationsEnabled
+  type: boolean
+  default: "true"
+  target: [ application, build, devtools ]
+  documentation: |
+    If disabled, dev tools will not use window animations when switching between expanded/minimised states. 
+    Note: window contents will still be animated.
+
 IntelliJDebuggerDispatchPort:
   key: compose.reload.idea.debugger.dispatch.port
   type: int


### PR DESCRIPTION
* Don't use rounded corners so that there is no white background visible
* Enable reload counter by default (so that there is no white section)
* Option `compose.reload.devToolsAnimationsEnabled` to enable/disable animations so that there is no big white background during transition. Option is enabled by default, maybe we can disable it for Linux?
* Increase minimised window size on windows so that the reload counter fully fits

Before:

https://github.com/user-attachments/assets/a068c307-b6f2-486e-b915-76b9b8cc2fed


After:

https://github.com/user-attachments/assets/b3d660bd-0753-4b4e-b649-fed83b154f7d

