### PR TITLE
Add property to enable dev tools debugging

### DIFF
--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotRunTasks.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotRunTasks.kt
@@ -109,9 +109,11 @@ internal fun JavaExec.configureJavaExecTaskForHotReload(compilation: Provider<Ko
     Further, project-specific capabilities such as logging or extended debugging support below
     */
 
-//    project.intellijDebuggerDispatchPort.orNull?.let { debuggerDispatchPort ->
-//        systemProperty(HotReloadProperty.IntelliJDebuggerDispatchPort.key, debuggerDispatchPort)
-//    }
+    if (project.composeReloadSubprocessDebuggingEnabled) {
+        project.intellijDebuggerDispatchPort.orNull?.let { debuggerDispatchPort ->
+            systemProperty(HotReloadProperty.IntelliJDebuggerDispatchPort.key, debuggerDispatchPort)
+        }
+    }
 
     val intellijDebuggerDispatchPort = project
         .composeReloadIntelliJDebuggerDispatchPortProvider.orNull

--- a/properties.yaml
+++ b/properties.yaml
@@ -195,6 +195,16 @@ IntelliJDebuggerDispatchPort:
     Launching the final application will respect this port, if present and provision a debugging session.
     This will allow a test to be deeply debuggable by just pressing 'Debug'
 
+SubprocessDebuggingEnabled:
+  key: compose.reload.subprocessDebuggingEnabled
+  type: boolean
+  default: "false"
+  target: [ build ]
+  documentation: |
+    Enable this property to allow propagating the 'idea.debugger.dispatch.port' to all subprocesses.
+    This is useful when debugging dev tools. Note: this may break the debugging of the user application if IJ is
+    not configured to accept multiple debugging sessions.
+
 JetBrainsRuntimeBinary:
   key: compose.reload.jbr.binary
   type: file


### PR DESCRIPTION
`compose.reload.idea.debugger.dispatch.port.propagate`

I'm open to suggestions for a better name 😃. I was not able to come up with anything better