### PR TITLE
Fix flaky devtools UI tests

### DIFF
--- a/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/DetachedSidecarUiTest.kt
+++ b/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/DetachedSidecarUiTest.kt
@@ -18,8 +18,6 @@ import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasClickAction
-import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onNodeWithTag
 import org.jetbrains.compose.devtools.Tag
 import org.jetbrains.compose.devtools.sidecar.DtDetachedSidecarContent
 import org.jetbrains.compose.devtools.states.BuildSystemState
@@ -43,47 +41,48 @@ class DetachedSidecarUiTest : SidecarBodyUiTest() {
     fun `test - logo clickable`() = runSidecarUiTest {
         // images are loaded asynchronously, so it may not be loaded at the start of the test
         // wait fot node to be loaded before performing checks
-        awaitNodeWithTag(Tag.HotReloadLogo, useUnmergedTree = true)
+        awaitNodeWithTag(Tag.HotReloadLogo)
             .assertExists()
             .assertHasNoClickAction()
     }
 
     @Test
     fun `test - reload counter`() = runSidecarUiTest {
-        onNodeWithTag(Tag.ReloadCounterText.name).assertDoesNotExist()
+        onNodeWithTag(Tag.ReloadCounterText).assertDoesNotExist()
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(1) }
-        onNodeWithTag(Tag.ReloadCounterText.name).assertTextContains("1", substring = true)
+        onNodeWithTag(Tag.ReloadCounterText).assertTextContains("1", substring = true)
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(2) }
-        onNodeWithTag(Tag.ReloadCounterText.name).assertTextContains("2", substring = true)
+        onNodeWithTag(Tag.ReloadCounterText).assertTextContains("2", substring = true)
     }
 
     @Test
     fun `test - reload status`() = runSidecarUiTest {
         states.updateState(ReloadState.Key) { ReloadState.Ok() }
-        onNodeWithTag(Tag.ReloadStatusSymbol.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusSymbol).assertExists()
             .assertContentDescriptionContains("Success")
-        onNodeWithTag(Tag.ReloadStatusText.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusText).assertExists()
             .assertTextContains("Success", substring = true)
 
         states.updateState(ReloadState.Key) { ReloadState.Failed("Oh-oh") }
-        onNodeWithTag(Tag.ReloadStatusSymbol.name).assertExists().assertContentDescriptionContains("Error")
-        onNodeWithTag(Tag.ReloadStatusText.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusSymbol).assertExists()
+            .assertContentDescriptionContains("Error")
+        onNodeWithTag(Tag.ReloadStatusText).assertExists()
             .assertTextContains("Failed", substring = true)
             .assertTextContains("Oh-oh", substring = true)
 
 
         states.updateState(ReloadState.Key) { ReloadState.Reloading() }
         assertEquals(
-            onNodeWithTag(Tag.ReloadStatusSymbol.name).assertExists()
+            onNodeWithTag(Tag.ReloadStatusSymbol).assertExists()
                 .fetchSemanticsNode().config.getOrNull(SemanticsProperties.ProgressBarRangeInfo),
             ProgressBarRangeInfo.Indeterminate
         )
-        onNodeWithTag(Tag.ReloadStatusText.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusText).assertExists()
             .assertTextContains("Reloading", substring = true)
 
-        onNodeWithTag(Tag.BuildSystemLogo.name).assertDoesNotExist()
+        onNodeWithTag(Tag.BuildSystemLogo).assertDoesNotExist()
 
         states.updateState(BuildSystemState.Key) { BuildSystemState.Initialised(BuildSystem.Gradle) }
         awaitNodeWithTag(Tag.BuildSystemLogo)
@@ -98,8 +97,8 @@ class DetachedSidecarUiTest : SidecarBodyUiTest() {
 
     @Test
     fun `test - error status`() = runSidecarUiTest {
-        onNodeWithTag(Tag.RuntimeErrorSymbol.name).assertDoesNotExist()
-        onNodeWithTag(Tag.RuntimeErrorText.name).assertDoesNotExist()
+        onNodeWithTag(Tag.RuntimeErrorSymbol).assertDoesNotExist()
+        onNodeWithTag(Tag.RuntimeErrorText).assertDoesNotExist()
 
         states.updateState(UIErrorState.Key) {
             UIErrorState(
@@ -111,17 +110,17 @@ class DetachedSidecarUiTest : SidecarBodyUiTest() {
             )
         }
 
-        onNodeWithTag(Tag.RuntimeErrorSymbol.name).assertExists()
-        onNodeWithTag(Tag.RuntimeErrorText.name).assertExists()
+        onNodeWithTag(Tag.RuntimeErrorSymbol).assertExists()
+        onNodeWithTag(Tag.RuntimeErrorText).assertExists()
             .assertTextContains("Uh-oh", substring = true)
             .assertTextContains("Something went wrong", substring = true)
 
-        onNodeWithTag(Tag.RuntimeErrorText.name).assertHasClickAction()
+        onNodeWithTag(Tag.RuntimeErrorText).assertHasClickAction()
     }
 
     @Test
     fun `test - actions`() = runSidecarUiTest {
-        onAllNodesWithTag(Tag.ActionButton.name)
+        onAllNodesWithTag(Tag.ActionButton)
             .assertCountEquals(4)
             .filter(hasClickAction())
             .assertCountEquals(4)
@@ -129,7 +128,7 @@ class DetachedSidecarUiTest : SidecarBodyUiTest() {
 
     @Test
     fun `test - expand minimise`() = runSidecarUiTest {
-        onNodeWithTag(Tag.ExpandMinimiseButton.name, useUnmergedTree = true)
+        onNodeWithTag(Tag.ExpandMinimiseButton)
             .assertDoesNotExist()
     }
 }

--- a/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/ExpandedSidecarUiTest.kt
+++ b/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/ExpandedSidecarUiTest.kt
@@ -22,12 +22,11 @@ import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasClickAction
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import org.jetbrains.compose.devtools.Tag
 import org.jetbrains.compose.devtools.sidecar.DtExpandedSidecarWindowContent
+import org.jetbrains.compose.devtools.sidecar.devToolsUseTransparency
 import org.jetbrains.compose.devtools.states.BuildSystemState
 import org.jetbrains.compose.devtools.states.ReloadCountState
 import org.jetbrains.compose.devtools.states.ReloadState
@@ -53,48 +52,49 @@ class ExpandedSidecarUiTest : SidecarBodyUiTest() {
     @Test
     fun `test - logo clickable`() = runSidecarUiTest {
         // images are loaded asynchronously, so it may not be loaded at the start of the test
-        // wait fot node to be loaded before performing checks
-        awaitNodeWithTag(Tag.HotReloadLogo, useUnmergedTree = true)
+        // wait for the node to be loaded before performing checks
+        awaitNodeWithTag(Tag.HotReloadLogo)
             .assertExists()
             .assertHasNoClickAction()
     }
 
     @Test
     fun `test - reload counter`() = runSidecarUiTest {
-        onNodeWithTag(Tag.ReloadCounterText.name).assertDoesNotExist()
+        onNodeWithTag(Tag.ReloadCounterText).assertDoesNotExist()
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(1) }
-        onNodeWithTag(Tag.ReloadCounterText.name).assertTextContains("1", substring = true)
+        onNodeWithTag(Tag.ReloadCounterText).assertTextContains("1", substring = true)
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(2) }
-        onNodeWithTag(Tag.ReloadCounterText.name).assertTextContains("2", substring = true)
+        onNodeWithTag(Tag.ReloadCounterText).assertTextContains("2", substring = true)
     }
 
     @Test
     fun `test - reload status`() = runSidecarUiTest {
         states.updateState(ReloadState.Key) { ReloadState.Ok() }
-        onNodeWithTag(Tag.ReloadStatusSymbol.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusSymbol).assertExists()
             .assertContentDescriptionContains("Success")
-        onNodeWithTag(Tag.ReloadStatusText.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusText).assertExists()
             .assertTextContains("Success", substring = true)
 
         states.updateState(ReloadState.Key) { ReloadState.Failed("Oh-oh") }
-        onNodeWithTag(Tag.ReloadStatusSymbol.name).assertExists().assertContentDescriptionContains("Error")
-        onNodeWithTag(Tag.ReloadStatusText.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusSymbol).assertExists()
+            .assertContentDescriptionContains("Error")
+        onNodeWithTag(Tag.ReloadStatusText).assertExists()
             .assertTextContains("Failed", substring = true)
             .assertTextContains("Oh-oh", substring = true)
 
 
         states.updateState(ReloadState.Key) { ReloadState.Reloading() }
         assertEquals(
-            onNodeWithTag(Tag.ReloadStatusSymbol.name).assertExists()
+            onNodeWithTag(Tag.ReloadStatusSymbol).assertExists()
                 .fetchSemanticsNode().config.getOrNull(SemanticsProperties.ProgressBarRangeInfo),
             ProgressBarRangeInfo.Indeterminate
         )
-        onNodeWithTag(Tag.ReloadStatusText.name).assertExists()
+        onNodeWithTag(Tag.ReloadStatusText).assertExists()
             .assertTextContains("Reloading", substring = true)
 
-        onNodeWithTag(Tag.BuildSystemLogo.name).assertDoesNotExist()
+        onNodeWithTag(Tag.BuildSystemLogo).assertDoesNotExist()
 
         states.updateState(BuildSystemState.Key) { BuildSystemState.Initialised(BuildSystem.Gradle) }
         awaitNodeWithTag(Tag.BuildSystemLogo)
@@ -110,8 +110,8 @@ class ExpandedSidecarUiTest : SidecarBodyUiTest() {
 
     @Test
     fun `test - error status`() = runSidecarUiTest {
-        onNodeWithTag(Tag.RuntimeErrorSymbol.name).assertDoesNotExist()
-        onNodeWithTag(Tag.RuntimeErrorText.name).assertDoesNotExist()
+        onNodeWithTag(Tag.RuntimeErrorSymbol).assertDoesNotExist()
+        onNodeWithTag(Tag.RuntimeErrorText).assertDoesNotExist()
 
         states.updateState(UIErrorState.Key) {
             UIErrorState(
@@ -123,17 +123,17 @@ class ExpandedSidecarUiTest : SidecarBodyUiTest() {
             )
         }
 
-        onNodeWithTag(Tag.RuntimeErrorSymbol.name).assertExists()
-        onNodeWithTag(Tag.RuntimeErrorText.name).assertExists()
+        onNodeWithTag(Tag.RuntimeErrorSymbol).assertExists()
+        onNodeWithTag(Tag.RuntimeErrorText).assertExists()
             .assertTextContains("Uh-oh", substring = true)
             .assertTextContains("Something went wrong", substring = true)
 
-        onNodeWithTag(Tag.RuntimeErrorText.name).assertHasClickAction()
+        onNodeWithTag(Tag.RuntimeErrorText).assertHasClickAction()
     }
 
     @Test
     fun `test - actions`() = runSidecarUiTest {
-        onAllNodesWithTag(Tag.ActionButton.name)
+        onAllNodesWithTag(Tag.ActionButton)
             .assertCountEquals(4)
             .filter(hasClickAction())
             .assertCountEquals(4)
@@ -142,38 +142,43 @@ class ExpandedSidecarUiTest : SidecarBodyUiTest() {
     @Test
     fun `test - expand minimise`() = runSidecarUiTest {
         // minimise the window
-        onAllNodesWithTag(Tag.ExpandMinimiseButton.name)
+        onAllNodesWithTag(Tag.ExpandMinimiseButton)
             .assertCountEquals(1)
             .onFirst()
             .assertHasClickAction()
             .performClick()
 
         // assert that the expanded UI elements are not visible
-        onAllNodesWithTag(Tag.ActionButton.name)
+        onAllNodesWithTag(Tag.ActionButton)
             .assertCountEquals(0)
 
-        onNodeWithTag(Tag.Console.name)
+        onNodeWithTag(Tag.Console)
             .assertDoesNotExist()
 
-        onNodeWithTag(Tag.ReloadCounterText.name)
-            .assertDoesNotExist()
+        if (devToolsUseTransparency) {
+            onNodeWithTag(Tag.ReloadCounterText)
+                .assertDoesNotExist()
+        } else {
+            onNodeWithTag(Tag.ReloadCounterText)
+                .assertTextContains("0", substring = true)
+        }
 
-        onNodeWithTag(Tag.ReloadStatusText.name)
+        onNodeWithTag(Tag.ReloadStatusText)
             .assertDoesNotExist()
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(1) }
 
-        onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true)
+        onNodeWithTag(Tag.ReloadCounterText)
             .assertTextContains("1", substring = true)
 
         // maximise the window
-        onAllNodesWithTag(Tag.ExpandMinimiseButton.name)
+        onAllNodesWithTag(Tag.ExpandMinimiseButton)
             .assertCountEquals(1)
             .onFirst()
             .assertHasClickAction()
             .performClick()
 
-        onNodeWithTag(Tag.ReloadCounterText.name)
+        onNodeWithTag(Tag.ReloadCounterText)
             .assertTextContains("1", substring = true)
     }
 }

--- a/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/MinimisedSidecarUiTest.kt
+++ b/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/MinimisedSidecarUiTest.kt
@@ -12,9 +12,7 @@ import androidx.compose.ui.test.assertContentDescriptionContains
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onParent
 import org.jetbrains.compose.devtools.Tag
 import org.jetbrains.compose.devtools.sidecar.DtMinimizedSidecarWindowContent
@@ -35,12 +33,12 @@ class MinimisedSidecarUiTest : SidecarBodyUiTest() {
 
     @Test
     fun `test - logo clickable`() = runSidecarUiTest {
-        awaitNodeWithTag(Tag.HotReloadLogo, useUnmergedTree = true)
+        awaitNodeWithTag(Tag.HotReloadLogo)
             .assertExists()
             .onParent()
             .assertHasClickAction()
 
-        onAllNodesWithTag(Tag.ExpandMinimiseButton.name, useUnmergedTree = true)
+        onAllNodesWithTag(Tag.ExpandMinimiseButton)
             .assertCountEquals(1)
             .onFirst()
             .assertHasClickAction()
@@ -49,30 +47,30 @@ class MinimisedSidecarUiTest : SidecarBodyUiTest() {
     @Test
     fun `test - reload counter`() = runSidecarUiTest {
         if (devToolsUseTransparency) {
-            onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertDoesNotExist()
+            onNodeWithTag(Tag.ReloadCounterText).assertDoesNotExist()
         } else {
-            onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertTextContains("0", substring = true)
+            onNodeWithTag(Tag.ReloadCounterText).assertTextContains("0", substring = true)
         }
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(1) }
-        onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertTextContains("1", substring = true)
+        onNodeWithTag(Tag.ReloadCounterText).assertTextContains("1", substring = true)
 
         states.updateState(ReloadCountState.Key) { ReloadCountState(2) }
-        onNodeWithTag(Tag.ReloadCounterText.name, useUnmergedTree = true).assertTextContains("2", substring = true)
+        onNodeWithTag(Tag.ReloadCounterText).assertTextContains("2", substring = true)
     }
 
     @Test
     fun `test - reload status`() = runSidecarUiTest {
         states.updateState(ReloadState.Key) { ReloadState.Reloading() }
-        onNodeWithTag(Tag.BuildSystemLogo.name).assertDoesNotExist()
+        onNodeWithTag(Tag.BuildSystemLogo).assertDoesNotExist()
 
         states.updateState(BuildSystemState.Key) { BuildSystemState.Initialised(BuildSystem.Gradle) }
-        awaitNodeWithTag(Tag.BuildSystemLogo, useUnmergedTree = true)
+        awaitNodeWithTag(Tag.BuildSystemLogo)
             .assertExists()
             .assertContentDescriptionContains(DtLogos.Image.GRADLE_LOGO.name)
 
         states.updateState(BuildSystemState.Key) { BuildSystemState.Initialised(BuildSystem.Amper) }
-        awaitNodeWithTag(Tag.BuildSystemLogo, useUnmergedTree = true)
+        awaitNodeWithTag(Tag.BuildSystemLogo)
             .assertExists()
             .assertContentDescriptionContains(DtLogos.Image.AMPER_LOGO.name)
     }

--- a/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/SidecarBodyUiTest.kt
+++ b/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/ui/SidecarBodyUiTest.kt
@@ -45,15 +45,27 @@ abstract class SidecarBodyUiTest {
         block()
     }
 
+    // wrappers for onNodeWithTag that change the default value for `useUnmergedTree`
+    // we need `useUnmergedTree = true` to prevent flakiness in tests
+    protected fun ComposeUiTest.onNodeWithTag(
+        tag: Tag,
+        useUnmergedTree: Boolean = true,
+    ) = onNodeWithTag(tag.name, useUnmergedTree = useUnmergedTree)
+
+    protected fun ComposeUiTest.onAllNodesWithTag(
+        tag: Tag,
+        useUnmergedTree: Boolean = true,
+    ) = onAllNodesWithTag(tag.name, useUnmergedTree = useUnmergedTree)
+
     protected fun ComposeUiTest.awaitNodeWithTag(
         tag: Tag,
-        useUnmergedTree: Boolean = false,
+        useUnmergedTree: Boolean = true,
         timeout: Duration = 10.seconds,
         pollingInterval: Duration = 200.milliseconds,
     ): SemanticsNodeInteraction = launchTask {
         while (onAllNodesWithTag(tag.name, useUnmergedTree).fetchSemanticsNodes().isEmpty()) {
             delay(pollingInterval)
         }
-        onNodeWithTag(tag.name, useUnmergedTree)
+        onNodeWithTag(tag, useUnmergedTree)
     }.getBlocking(timeout = timeout).getOrThrow()
 }


### PR DESCRIPTION
Use `useUnmergedTree = true` by default to handle cases when the compose tree gets merged before checks are performed