### PR TITLE
Stabilise properties

### DIFF
--- a/buildSrc/src/main/kotlin/properties/GenerateHotReloadEnvironmentTask.kt
+++ b/buildSrc/src/main/kotlin/properties/GenerateHotReloadEnvironmentTask.kt
@@ -65,7 +65,7 @@ open class GenerateHotReloadEnvironmentTask : DefaultTask() {
         val caseTemplate = """
             /**
             * {{documentation}}
-            */
+            */{{delicateApi}}
             {{name}}(
                 "{{key}}",
                 type = {{type}},
@@ -82,6 +82,10 @@ open class GenerateHotReloadEnvironmentTask : DefaultTask() {
                     if (property.default != null) {
                         "documentation"("- default: '${property.default}'")
                     }
+                    "delicateApi"(
+                        "\n@org.jetbrains.compose.reload.DelicateHotReloadApi"
+                            .takeIf { property.isDelicateApi } ?: ""
+                    )
                     "name"(property.name)
                     "key"(property.key)
                     "default"(if (property.default != null) property.renderDefault() else """"null"""")

--- a/buildSrc/src/main/kotlin/properties/parseHotReloadProperties.kt
+++ b/buildSrc/src/main/kotlin/properties/parseHotReloadProperties.kt
@@ -45,7 +45,8 @@ private fun parseHotReloadProperty(
             DeclaredHotReloadProperty.Target.values().firstOrNull { it.name.equals(declaredTarget, ignoreCase = true) }
                 ?: error("Property '$name' has invalid 'target' field: $declaredTarget")
         },
-        documentation = node.getScalar("documentation")?.content
+        isDelicateApi = node.getScalar("isDelicateApi")?.content?.toBooleanStrict() == true,
+        documentation = node.getScalar("documentation")?.content,
     )
 }
 
@@ -57,7 +58,8 @@ internal class DeclaredHotReloadProperty(
     val type: Type,
     val enumClass: String?,
     val targets: List<Target>,
-    val documentation: String?
+    val isDelicateApi: Boolean,
+    val documentation: String?,
 ) {
     enum class Type {
         String, Boolean, Int, Long, File, Files, Enum

--- a/properties.schema.json
+++ b/properties.schema.json
@@ -34,6 +34,10 @@
             "enum": ["build", "devtools", "application"]
           }
         },
+        "isDelicateApi": {
+          "type": "boolean",
+          "default": false
+        },
         "documentation": {
           "type": "string"
         }

--- a/properties.yaml
+++ b/properties.yaml
@@ -100,7 +100,7 @@ GradleBuildRoot:
 GradleBuildProject:
   key: gradle.build.project
   type: string
-  target: [ application,devtools ]
+  target: [ application, devtools ]
   documentation: |
     The gradle 'path' to the 'project' which is currently executed and needs recompiling.
     e.g. ':app:' or ':' or ':someModule:composeApp'
@@ -118,10 +118,12 @@ GradleBuildContinuous:
   type: boolean
   default: "false"
   target: [ application, devtools, build ]
+  isDelicateApi: true
   documentation: |
     - true: Compose Hot Reload will start a recompiler Gradle Daemon, which will continuously rebuilt/reload the project
     by watching all  inputs to the build
     - false: The user is expected to rebuild/reload manually by launching a task (or using tooling)
+    Continuous mode is subject to change and might be removed in the future.
 
 AmperBuildRoot:
   key: amper.build.root
@@ -163,9 +165,11 @@ DevToolsTransparencyEnabled:
   default: "(Os.currentOrNull() != Os.Linux).toString()"
   defaultIsExpression: true
   target: [ application, build, devtools ]
+  isDelicateApi: true
   documentation: |
     Some platforms might not be able to render transparency correctly (e.g. some linux environments).
-    This property will allow such platforms to disable/enable transparency
+    This property will allow such platforms to disable/enable transparency. This property is subject to change
+    if the issues with transparency rendering are resolved..
 
 DevToolsDetached:
   key: compose.reload.devToolsDetached
@@ -180,9 +184,11 @@ DevToolsAnimationsEnabled:
   type: boolean
   default: "true"
   target: [ application, build, devtools ]
+  isDelicateApi: true
   documentation: |
     If disabled, dev tools will not use window animations when switching between expanded/minimised states. 
-    Note: window contents will still be animated.
+    Note: window contents will still be animated. This property is present because of some platform-specific issues with
+    window management. Subject to change and might be removed in the future, if the current issues are resolved.
 
 IntelliJDebuggerDispatchPort:
   key: compose.reload.idea.debugger.dispatch.port
@@ -209,10 +215,11 @@ SubprocessDebuggingEnabled:
   type: boolean
   default: "false"
   target: [ build ]
+  isDelicateApi: true
   documentation: |
     Enable this property to allow propagating the 'idea.debugger.dispatch.port' to all subprocesses.
     This is useful when debugging dev tools. Note: this may break the debugging of the user application if IJ is
-    not configured to accept multiple debugging sessions.
+    not configured to accept multiple debugging sessions. Not recommended to use outside of hot reload debugging.
 
 JetBrainsRuntimeBinary:
   key: compose.reload.jbr.binary
@@ -244,7 +251,6 @@ IdeaComposeHotReloadSupportVersion:
   key: idea.compose.hot-reload.version
   type: int
   target: [ build, application, devtools ]
-
   documentation: |
     Set by IntelliJ during builds to convey its 'support level' for hot reload.
     Not Present, but 'idea.compose.hot-reload' being set: Supports running hot run tasks
@@ -255,25 +261,31 @@ StdinFile:
   key: compose.reload.stdinFile
   type: file
   target: [ build, application, devtools ]
+  isDelicateApi: true
   documentation: |
     Used by 'async'/'non-blocking' launches of the application.
     Will point to the stdin file (can be pipe)
+    'async'/'non-blocking' mode is subject to change and might be removed in the future.
 
 StdoutFile:
   key: compose.reload.stdoutFile
   type: file
   target: [ build, application, devtools ]
+  isDelicateApi: true
   documentation: |
     Used by 'async'/'non-blocking' launches of the application.
     Will point to a file where the stdout is supposed to be written to.
+    'async'/'non-blocking' mode is subject to change and might be removed in the future.
 
 StderrFile:
   key: compose.reload.stderrFile
   type: file
   target: [ build, application, devtools ]
+  isDelicateApi: true
   documentation: |
     Used by 'async'/'non-blocking' launches of the application.
     Will point to a file where the stderr is supposed to be written to.
+    'async'/'non-blocking' mode is subject to change and might be removed in the future.
 
 ParentPid:
   key: compose.reload.parentPid
@@ -323,7 +335,9 @@ ResourcesDirtyResolverEnabled:
   type: boolean
   default: "false"
   target: [application, build, devtools]
+  isDelicateApi: true
   documentation: |
     Enables/Disables automatically re-composing scopes using resources
     See: https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-resources.html
     See: https://github.com/JetBrains/compose-hot-reload/issues/151
+    Feature is still in development and subject to change in the future.


### PR DESCRIPTION
Mark non-stable properties as delicate APIs and add explanation in documentation.

Main changes:
1. Continuous mode marked as delicate api --- we're planning to move away from that mode
2. Properties related to `async` launches are marked as delicate api --- this mode may lead to a lot of frustration and confusion if anything goes wrong, so I don't exclude the idea of changes in the future
3. Features that are under development (e.g. resource reloading) are marked with 'delicate api'
4. Properties introduced because of external issues (e.g. window management on different platforms) are marked as delicate: may be removed if external issues are resolved