### PR TITLE
Option for a recompiler warmup

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompilerExtension.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompilerExtension.kt
@@ -37,7 +37,7 @@ internal class GradleRecompilerExtension : RecompilerExtension {
         }
 
         /* Side Effect */
-        if (HotReloadEnvironment.gradleBuildContinuous) {
+        if (HotReloadEnvironment.gradleWarmupEnabled || HotReloadEnvironment.gradleBuildContinuous) {
             OrchestrationMessage.RecompileRequest().sendAsync()
         }
 

--- a/hot-reload-gradle-plugin/api/hot-reload-gradle-plugin.api
+++ b/hot-reload-gradle-plugin/api/hot-reload-gradle-plugin.api
@@ -9,6 +9,7 @@ public abstract class org/jetbrains/compose/reload/gradle/AbstractComposeHotRun 
 
 public abstract interface class org/jetbrains/compose/reload/gradle/ComposeHotReloadArgumentsBuilder {
 	public abstract fun isAutoRecompileEnabled (Lorg/gradle/api/provider/Provider;)V
+	public abstract fun isRecompilerWarmupEnabled (Lorg/gradle/api/provider/Provider;)V
 	public abstract fun setAgentJar (Lorg/gradle/api/file/FileCollection;)V
 	public abstract fun setArgFile (Lorg/gradle/api/provider/Provider;)V
 	public abstract fun setDevToolsClasspath (Lorg/gradle/api/file/FileCollection;)V

--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/arguments.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/arguments.kt
@@ -41,6 +41,7 @@ sealed interface ComposeHotReloadArgumentsBuilder {
     fun setReloadTaskName(name: Provider<String>)
     fun setReloadTaskName(name: String)
     fun isAutoRecompileEnabled(isAutoRecompileEnabled: Provider<Boolean>)
+    fun isRecompilerWarmupEnabled(isRecompilerWarmupEnabled: Provider<Boolean>)
 }
 
 @DelicateHotReloadApi
@@ -118,6 +119,12 @@ internal class ComposeHotReloadArguments(project: Project) :
     @get:JvmName("getIsAutoRecompileEnabled")
     val isAutoRecompileEnabled: Property<Boolean> = project.objects.property(Boolean::class.java)
         .value(project.composeReloadGradleBuildContinuous)
+
+    @get:Input
+    @get:JvmName("getIsRecompilerWarmupEnabled")
+    val isRecompilerWarmupEnabled: Property<Boolean> = project.objects.property(Boolean::class.java)
+        .value(project.composeReloadGradleWarmupEnabled)
+
 
     @get:Input
     @get:Optional
@@ -207,6 +214,10 @@ internal class ComposeHotReloadArguments(project: Project) :
         this.isAutoRecompileEnabled.set(isAutoRecompileEnabled.orElse(true))
     }
 
+    override fun isRecompilerWarmupEnabled(isRecompilerWarmupEnabled: Provider<Boolean>) {
+        this.isRecompilerWarmupEnabled.set(isRecompilerWarmupEnabled.orElse(false))
+    }
+
     override fun asArguments(): Iterable<String> = buildList {
         /* Signal that this execution runs with Hot Reload */
         add("-D${HotReloadProperty.IsHotReloadActive.key}=true")
@@ -270,6 +281,7 @@ internal class ComposeHotReloadArguments(project: Project) :
             add("-D${HotReloadProperty.GradleBuildTask.key}=${reloadTaskName.get()}")
         }
         add("-D${HotReloadProperty.GradleBuildContinuous.key}=${isAutoRecompileEnabled.getOrElse(true)}")
+        add("-D${HotReloadProperty.GradleWarmupEnabled.key}=${isRecompilerWarmupEnabled.getOrElse(false)}")
         javaHome.orNull?.let { javaHome ->
             add("-D${HotReloadProperty.GradleJavaHome.key}=$javaHome")
         }

--- a/properties.yaml
+++ b/properties.yaml
@@ -125,6 +125,17 @@ GradleBuildContinuous:
     - false: The user is expected to rebuild/reload manually by launching a task (or using tooling)
     Continuous mode is subject to change and might be removed in the future.
 
+GradleWarmupEnabled:
+  key: compose.reload.build.warmup
+  type: boolean
+  default: "false"
+  target: [ application, devtools, build ]
+  isDelicateApi: true
+  documentation: |
+    - true: Compose Hot Reload will launch a warmup recompile request when the application is started, to ensure that
+    the recompiler Gradle daemon is running and ready to handle requests
+    - false: No warmup request will be sent, first reload request may take longer time
+
 AmperBuildRoot:
   key: amper.build.root
   type: string


### PR DESCRIPTION
* `compose.reload.build.warmup` option to enable warmup of the recompiler at the start of the app
* `ReloadState` is now updated on recompile request --- better/faster visual feedback for the user