### PR TITLE
Fix missing 'pidFile' after executing a restart

### DIFF
--- a/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/LockFile.kt
+++ b/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/LockFile.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.core
+
+import org.jetbrains.compose.reload.InternalHotReloadApi
+import java.nio.channels.FileChannel
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.READ
+import java.nio.file.StandardOpenOption.WRITE
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+@InternalHotReloadApi
+public class LockFile(private val lock: Path) {
+
+    private val internalLock = ReentrantLock()
+
+    public fun <T> withLock(action: () -> T): T {
+        if (internalLock.isHeldByCurrentThread) return action()
+
+        internalLock.withLock {
+            val lockFileChannel = FileChannel.open(lock, READ, WRITE, CREATE)
+            return lockFileChannel.lock().use { action() }
+        }
+    }
+}

--- a/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/PidFileInfo.kt
+++ b/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/PidFileInfo.kt
@@ -8,7 +8,9 @@ package org.jetbrains.compose.reload.core
 import java.io.ByteArrayOutputStream
 import java.nio.file.Path
 import java.util.Properties
+import kotlin.io.path.deleteIfExists
 import kotlin.io.path.inputStream
+import kotlin.io.path.isRegularFile
 import kotlin.io.path.outputStream
 
 public fun PidFileInfo(path: Path): Try<PidFileInfo> = Try {
@@ -55,4 +57,14 @@ public fun Path.writePidFile(pidFileInfo: PidFileInfo) {
     outputStream().buffered().use { output ->
         pidFileInfo.toProperties().store(output, null)
     }
+}
+
+
+/**
+ * Deletes the pid file if its content matches the given [expected] [PidFileInfo]
+ */
+public fun Path.deleteMyPidFileIfExists(expected: PidFileInfo): Boolean {
+    if (!this.isRegularFile()) return false
+    if (PidFileInfo(this).getOrNull() != expected) return false
+    return deleteIfExists()
 }

--- a/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/pidFileLock.kt
+++ b/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/pidFileLock.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.core
+
+import org.jetbrains.compose.reload.InternalHotReloadApi
+
+/**
+ * By default, the hot reload 'run' directory is inferred by passing the [HotReloadEnvironment.pidFile].
+ * The parent of the [HotReloadEnvironment.pidFile] is considered the 'run directory' which might
+ * contain additional files (such as logs).
+ *
+ * Sometimes, some IO operations in this directory require inter process locking
+ * (e.g., modifications to the pid file). This [runDirectoryLockFile] is used for this purpose.
+ */
+@InternalHotReloadApi
+public val runDirectoryLockFile: LockFile? = run {
+    val pidFile = HotReloadEnvironment.pidFile ?: return@run null
+    LockFile(pidFile.parent.resolve(".lock"))
+}

--- a/hot-reload-core/src/test/kotlin/LockFileTest.kt
+++ b/hot-reload-core/src/test/kotlin/LockFileTest.kt
@@ -1,0 +1,38 @@
+import org.jetbrains.compose.reload.core.LockFile
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+class LockFileTest {
+
+    @Test
+    fun `test - withLock`(@TempDir tempDir: Path) {
+        val lockFile = LockFile(tempDir.resolve(".lock"))
+        assertEquals("hello", lockFile.withLock { "hello" })
+    }
+
+    @Test
+    fun `test - multiple threads`(@TempDir tempDir: Path) {
+        val lockFile = LockFile(tempDir.resolve(".lock"))
+        var state = 0
+        val result = mutableListOf<Int>()
+        val threads = mutableListOf<Thread>()
+
+        repeat(12) {
+            threads += thread {
+                lockFile.withLock { result.add(state++) }
+            }
+        }
+
+        threads.forEach { it.join() }
+        assertEquals(12, result.size)
+        assertEquals(List(12) { it }, result)
+    }
+}

--- a/hot-reload-core/src/test/kotlin/PidFileInfoTest.kt
+++ b/hot-reload-core/src/test/kotlin/PidFileInfoTest.kt
@@ -1,12 +1,17 @@
 import org.jetbrains.compose.reload.core.PidFileInfo
+import org.jetbrains.compose.reload.core.deleteMyPidFileIfExists
 import org.jetbrains.compose.reload.core.exceptionOrNull
 import org.jetbrains.compose.reload.core.getOrThrow
 import org.jetbrains.compose.reload.core.writePidFile
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import java.util.Properties
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /*
@@ -41,5 +46,19 @@ class PidFileInfoTest {
     fun `test - read on missing file`(@TempDir tempDir: Path) {
         val file = tempDir.resolve("test.properties")
         PidFileInfo(file).exceptionOrNull() ?: fail("Expected exception thrown")
+    }
+
+    @Test
+    fun `test - deleteMyPidFileIfExists`(@TempDir tempDir: Path) {
+        val file = tempDir.resolve("test.properties")
+        val source = PidFileInfo(pid = 42, 69)
+        file.writePidFile(source)
+
+        assertFalse(file.deleteMyPidFileIfExists(source.copy(pid = 43)))
+        assertTrue(file.isRegularFile())
+        assertEquals(source, PidFileInfo(file).getOrThrow())
+
+        assertTrue(file.deleteMyPidFileIfExists(source.copy()))
+        assertFalse(file.exists())
     }
 }


### PR DESCRIPTION
The issue was a race between the new process
creating its new pidFile vs the old process
deleting the old file.

The solution is to implement an atomic 'deleteMyPidFileIfExists'