### PR TITLE
Fix devtools action bar layout

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtSidecarActionBar.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/sidecar/DtSidecarActionBar.kt
@@ -41,6 +41,15 @@ fun DtSidecarActionBar(modifier: Modifier = Modifier.Companion) {
             )
         }
 
+        DtTextButton(
+            text = "Reset",
+            icon = DtImages.Image.DELETE_ICON,
+            tag = Tag.ActionButton,
+            onClick = {
+                OrchestrationMessage.CleanCompositionRequest().sendAsync()
+            }
+        )
+
         if (
             (HotReloadEnvironment.argFile?.exists() == true &&
                 HotReloadEnvironment.mainClass != null)
@@ -52,16 +61,6 @@ fun DtSidecarActionBar(modifier: Modifier = Modifier.Companion) {
                 onClick = restartAction()
             )
         }
-
-
-        DtTextButton(
-            text = "Reset Composition",
-            icon = DtImages.Image.DELETE_ICON,
-            tag = Tag.ActionButton,
-            onClick = {
-                OrchestrationMessage.CleanCompositionRequest().sendAsync()
-            }
-        )
 
         DtTextButton(
             text = "Exit",


### PR DESCRIPTION
* Rename "Reset Composition" to "Reset" so that all the buttons fit in one row
* Move the "Reset" button before "Restart" so that the actions consistently increase in "severity" from left to right