### PR TITLE
Hide devtools ui on shutdown request

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/main.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/main.kt
@@ -26,6 +26,7 @@ import org.jetbrains.compose.devtools.sidecar.DtAttachedSidecarWindow
 import org.jetbrains.compose.devtools.sidecar.DtDetachedSidecarWindow
 import org.jetbrains.compose.devtools.sidecar.DtDetachedStatusBar
 import org.jetbrains.compose.devtools.sidecar.devToolsUseTransparency
+import org.jetbrains.compose.devtools.states.DtLifecycleState
 import org.jetbrains.compose.devtools.states.WindowsState
 import org.jetbrains.compose.devtools.states.launchConsoleLogState
 import org.jetbrains.compose.devtools.states.launchReloadCountState
@@ -79,6 +80,13 @@ fun main() {
             applicationScope.coroutineContext.statesOrThrow
         ) {
             val windowsState = WindowsState.composeValue()
+            val lifecycleState = DtLifecycleState.composeValue()
+
+            if (!lifecycleState.isActive) {
+                logger.info("DevTools UI is shutting down")
+                return@installEvas
+            }
+
             if (devToolsDetached) {
                 DtDetachedSidecarWindow()
             }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/shutdown.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/shutdown.kt
@@ -5,6 +5,9 @@
 
 package org.jetbrains.compose.devtools
 
+import io.sellmair.evas.statesOrNull
+import io.sellmair.evas.statesOrThrow
+import org.jetbrains.compose.devtools.states.DtLifecycleState
 import org.jetbrains.compose.reload.core.Disposable
 import org.jetbrains.compose.reload.core.HotReloadEnvironment
 import org.jetbrains.compose.reload.core.Try
@@ -58,6 +61,7 @@ internal fun setupShutdownProcedure() {
 }
 
 internal fun shutdown(): Nothing {
+    applicationScope.coroutineContext.statesOrNull?.setState(DtLifecycleState.Key, DtLifecycleState(isActive = false))
     exitProcess(0)
 }
 

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/DtLifecycleState.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/DtLifecycleState.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.devtools.states
+
+import io.sellmair.evas.State
+
+data class DtLifecycleState(
+    val isActive: Boolean,
+) : State {
+    companion object Key : State.Key<DtLifecycleState> {
+        override val default: DtLifecycleState = DtLifecycleState(isActive = true)
+    }
+}


### PR DESCRIPTION
Added `DtLifecycleState` that holds `isActive` property. It flips on `ShutdownRequest`, and the devtools ui is hidden accordingly.

Notes:
* `appliсationScope.cancel()` did not speed up the ui shutdown, so I opted to just return
* decided to use simple boolean property, we can easily extend it in the future if we want. Considering this is devtools internal api --- will not cause any compatibility problems