### PR TITLE
Implement 'OrchestrationLoggerState' to indicate if (and which) loggers are active in the orchestration

### DIFF
--- a/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/logging.kt
+++ b/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/logging.kt
@@ -14,10 +14,12 @@ import org.jetbrains.compose.reload.core.displayString
 import org.jetbrains.compose.reload.core.info
 import org.jetbrains.compose.reload.core.invokeOnFinish
 import org.jetbrains.compose.reload.core.invokeOnStop
+import org.jetbrains.compose.reload.core.launchOnFinish
 import org.jetbrains.compose.reload.core.launchTask
 import org.jetbrains.compose.reload.core.withThread
 import org.jetbrains.compose.reload.core.withType
 import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
+import org.jetbrains.compose.reload.orchestration.OrchestrationLoggerState
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.CriticalException
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.LogMessage
 import org.jetbrains.compose.reload.orchestration.toMessage
@@ -60,6 +62,14 @@ internal fun OrchestrationHandle.startDispatchingLogs() {
     }
 
     subtask {
+        subtask {
+            val loggerId = OrchestrationLoggerState.LoggerId.create()
+            update(OrchestrationLoggerState) { state -> state.withLogger(loggerId) }
+            launchOnFinish {
+                update(OrchestrationLoggerState) { state -> state.withoutLogger(loggerId) }
+            }
+        }
+
         orchestration.messages.withType<LogMessage>().collect { message ->
             incomingLoggingQueue.add(message)
         }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/logging.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/logging.kt
@@ -7,7 +7,9 @@ package org.jetbrains.compose.devtools
 
 import org.jetbrains.compose.reload.core.Logger
 import org.jetbrains.compose.reload.core.Queue
+import org.jetbrains.compose.reload.core.await
 import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
+import org.jetbrains.compose.reload.orchestration.OrchestrationLoggerState
 import org.jetbrains.compose.reload.orchestration.toMessage
 
 internal val devtoolsLoggingQueue = Queue<Logger.Log>()
@@ -19,7 +21,15 @@ internal class DevToolsLoggerDispatch : Logger.Dispatch {
 }
 
 internal fun OrchestrationHandle.startLoggingDispatch() = subtask {
+    val loggingState = states.get(OrchestrationLoggerState)
+
     while (true) {
+
+        /* Await at lest one logger to be present in the orchestration, to avoid logs being swallowed */
+        if (loggingState.value.loggers.isEmpty()) {
+            loggingState.await { state -> state.loggers.isNotEmpty() }
+        }
+
         val log = devtoolsLoggingQueue.receive()
         try {
             send(log.toMessage())

--- a/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestartionLogging.kt
+++ b/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestartionLogging.kt
@@ -8,7 +8,86 @@ package org.jetbrains.compose.reload.orchestration
 import org.jetbrains.compose.reload.InternalHotReloadApi
 import org.jetbrains.compose.reload.core.Environment
 import org.jetbrains.compose.reload.core.Logger
-import org.jetbrains.compose.reload.core.Queue
+import org.jetbrains.compose.reload.core.Try
+import org.jetbrains.compose.reload.core.Type
+import org.jetbrains.compose.reload.core.encodeByteArray
+import org.jetbrains.compose.reload.core.readString
+import org.jetbrains.compose.reload.core.tryDecode
+import org.jetbrains.compose.reload.core.type
+import org.jetbrains.compose.reload.core.writeString
+import java.util.UUID
+
+
+/**
+ * Indicates if actual 'loggers' are connected to the orchestration.
+ * If there are no loggers present, [LogMessage]'s sent into the orchestration might be lost!
+ */
+@InternalHotReloadApi
+public class OrchestrationLoggerState(
+    public val loggers: Set<LoggerId>
+) : OrchestrationState {
+
+    public fun withLogger(loggerId: LoggerId): OrchestrationLoggerState {
+        return OrchestrationLoggerState(loggers + loggerId)
+    }
+
+    public fun withoutLogger(loggerId: LoggerId): OrchestrationLoggerState {
+        return OrchestrationLoggerState(loggers - loggerId)
+    }
+
+    override fun hashCode(): Int {
+        return loggers.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OrchestrationLoggerState) return false
+        if (loggers != other.loggers) return false
+        return true
+    }
+
+    override fun toString(): String {
+        return "OrchestrationLoggingState(activeLoggers=$loggers)"
+    }
+
+    @JvmInline
+    @InternalHotReloadApi
+    public value class LoggerId(public val value: String) {
+        @InternalHotReloadApi
+        public companion object {
+            public fun create(): LoggerId = LoggerId(UUID.randomUUID().toString())
+        }
+    }
+
+    @InternalHotReloadApi
+    public companion object Key : OrchestrationStateKey<OrchestrationLoggerState>() {
+        override val id: OrchestrationStateId<OrchestrationLoggerState> = stateId()
+        override val default: OrchestrationLoggerState = OrchestrationLoggerState(emptySet())
+    }
+}
+
+internal class OrchestrationLoggerStateEncoder : OrchestrationStateEncoder<OrchestrationLoggerState> {
+    override val type: Type<OrchestrationLoggerState> = type()
+
+    override fun encode(state: OrchestrationLoggerState): ByteArray = encodeByteArray {
+        writeInt(state.loggers.size)
+        state.loggers.forEach { loggerId ->
+            writeString(loggerId.value)
+        }
+    }
+
+    override fun decode(data: ByteArray): Try<OrchestrationLoggerState> = data.tryDecode {
+        val size = readInt()
+        if (size == 0) return@tryDecode OrchestrationLoggerState(emptySet())
+
+        OrchestrationLoggerState(buildSet {
+            repeat(size) {
+                this += OrchestrationLoggerState.LoggerId(readString())
+            }
+        })
+    }
+}
+
 
 @InternalHotReloadApi
 public fun Logger.Log.toMessage(): OrchestrationMessage.LogMessage {
@@ -33,7 +112,7 @@ public fun LogMessage(
     timestamp: Long = System.currentTimeMillis(),
     level: Logger.Level = Logger.Level.Debug,
     throwableClassName: String? = null,
-    throwableMessage : String? = null,
+    throwableMessage: String? = null,
     throwableStacktrace: List<StackTraceElement>? = null
 ): OrchestrationMessage.LogMessage = OrchestrationMessage.LogMessage(
     message = message,
@@ -46,18 +125,3 @@ public fun LogMessage(
     throwableMessage = throwableMessage,
     throwableStacktrace = throwableStacktrace,
 )
-@InternalHotReloadApi
-public fun OrchestrationHandle.startLoggerDispatch(): Logger.Dispatch {
-    val queue = Queue<Logger.Log>()
-
-    subtask("loggerDispatch") {
-        while (true) {
-            val log = queue.receive()
-            send(log.toMessage())
-        }
-    }
-
-    return Logger.Dispatch { log ->
-        queue.add(log)
-    }
-}

--- a/hot-reload-orchestration/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
+++ b/hot-reload-orchestration/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
@@ -3,3 +3,4 @@
 # Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 #
 org.jetbrains.compose.reload.orchestration.OrchestrationConnectionsStateEncoder
+org.jetbrains.compose.reload.orchestration.OrchestrationLoggerStateEncoder

--- a/hot-reload-orchestration/src/test/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationLoggerStateTest.kt
+++ b/hot-reload-orchestration/src/test/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationLoggerStateTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.orchestration
+
+import org.jetbrains.compose.reload.core.getOrThrow
+import org.jetbrains.compose.reload.orchestration.OrchestrationLoggerState.LoggerId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OrchestrationLoggerStateTest {
+    @Test
+    fun `test - encode decode`() {
+        val encoder = encoderOfOrThrow<OrchestrationLoggerState>()
+
+        val empty = OrchestrationLoggerState(emptySet())
+        assertEquals(empty, encoder.decode(encoder.encode(empty)).getOrThrow())
+
+        val nonEmpty = OrchestrationLoggerState(setOf(LoggerId("a"), LoggerId("b")))
+        assertEquals(nonEmpty, encoder.decode(encoder.encode(nonEmpty)).getOrThrow())
+    }
+}

--- a/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/HotReloadTestFixture.kt
+++ b/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/HotReloadTestFixture.kt
@@ -38,7 +38,6 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationServer
 import org.jetbrains.compose.reload.orchestration.asChannel
 import org.jetbrains.compose.reload.orchestration.asFlow
 import org.jetbrains.compose.reload.orchestration.sendAsync
-import org.jetbrains.compose.reload.orchestration.startLoggerDispatch
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.coroutines.CoroutineContext


### PR DESCRIPTION
This can be used to identify when dispatching log messages to the orchestration is safe