### PR TITLE
Fixed glow shader

### DIFF
--- a/hot-reload-runtime-jvm/src/main/resources/shaders/glow.glsl
+++ b/hot-reload-runtime-jvm/src/main/resources/shaders/glow.glsl
@@ -150,8 +150,8 @@ half4 renderGlow(vec2 position, vec2 halfSize) {
 
     // Combine masks and color
     float strength = clamp(rimMask * 0.9 + haloMask * 0.7, 0.0, 1.0);
-    strength *= clamp(0.8, 1.0, breathe);
-    strength = clamp(0.9, 1.0, strength);
+    strength *= clamp(breathe, 0.8, 1.0);
+    strength = clamp(strength, 0.0, 1.0);
 
     half3 color = mesh3(position) * half(strength);
     half alpha = half(iBaseColor.a) * half(strength);


### PR DESCRIPTION
Fixes #368

The clamp method was used incorrectly in the GLSL shader.

| Before | After |
|--------|--------|
| <img width="630" height="840" alt="image" src="https://github.com/user-attachments/assets/9422c722-646c-4d37-9763-7373aae2cc7a" /> | <img width="630" height="840" alt="image" src="https://github.com/user-attachments/assets/cfde0759-214e-437a-a96d-c5514b9b464a" /> |