### PR TITLE
Fix potential deadlock in `WorkerThread`

### DIFF
--- a/hot-reload-core/src/benchmark/kotlin/org/jetbrains/compose/reload/core/WorkerThreadBenchmark.kt
+++ b/hot-reload-core/src/benchmark/kotlin/org/jetbrains/compose/reload/core/WorkerThreadBenchmark.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.core
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+import java.util.concurrent.TimeUnit
+
+@kotlinx.benchmark.State(Scope.Benchmark)
+open class WorkerThreadBenchmark {
+    lateinit var worker: WorkerThread
+
+    @Setup
+    fun setup() {
+        worker = WorkerThread("benchmark")
+    }
+
+    @TearDown
+    fun teardown() {
+        worker.close()
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+    fun invokeWorker(blackHole: Blackhole) {
+        blackHole.consume(
+            worker.invoke { }
+                .getBlocking().getOrThrow()
+        )
+    }
+}


### PR DESCRIPTION
Is is possible to receive a situation when the mai loop of `WorkerThread::run` is stuck on `queue.take()` on shutdown if the decrement of `pendingDispatches` happened after the work has been taken from the queue. 

Now we add an empty work to the `WorkingThread` queue if the `pendingDispatches` has reached `Int.MIN_VALUE` to awaken the `run` loop