### PR TITLE
[gradle] Do not resolve kotlin-stdlib inside the agent-classpath

### DIFF
--- a/hot-reload-core/src/testFixtures/kotlin/org/jetbrains/compose/reload/core/testFixtures/classpathAssertions.kt
+++ b/hot-reload-core/src/testFixtures/kotlin/org/jetbrains/compose/reload/core/testFixtures/classpathAssertions.kt
@@ -83,3 +83,7 @@ private data class PathRegex(private val regex: Regex) : FileMatcher {
 fun interface FileMatcher {
     fun matches(file: File): Boolean
 }
+
+operator fun FileMatcher.minus(other: FileMatcher): FileMatcher = FileMatcher { file ->
+    this@minus.matches(file) && !other.matches(file)
+}

--- a/hot-reload-gradle-core/src/main/kotlin/org/jetbrains/compose/reload/gradle/agentConfiguration.kt
+++ b/hot-reload-gradle-core/src/main/kotlin/org/jetbrains/compose/reload/gradle/agentConfiguration.kt
@@ -14,6 +14,7 @@ import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
 import org.gradle.api.file.FileCollection
+import org.gradle.kotlin.dsl.exclude
 import org.gradle.kotlin.dsl.named
 import org.jetbrains.compose.reload.InternalHotReloadApi
 import org.jetbrains.compose.reload.core.HOT_RELOAD_VERSION
@@ -37,6 +38,15 @@ internal val Project.composeHotReloadAgentConfiguration: Configuration
             configuration.dependencies.add(
                 project.dependencies.create("org.jetbrains.compose.hot-reload:hot-reload-agent:$HOT_RELOAD_VERSION")
             )
+
+            /**
+             * We're resolving the agent classpath as part of the System ClassLoader for applications.
+             * This classpath will also resolve in 'isolation' and will be put into the leading position
+             * of the classpath. Since we resolve a 'regular' (not shadowed) classpath, we ensure that
+             * we do not include the kotlin-stdlib from this classpath:
+             * We expect the user application to provide a kotlin-stdlib for us.
+             */
+            configuration.exclude("org.jetbrains.kotlin", "kotlin-stdlib")
         }
     }
 

--- a/hot-reload-gradle-plugin/src/test/kotlin/org/jetbrains/compose/reload/gradle/tests/RuntimeClasspathTest.kt
+++ b/hot-reload-gradle-plugin/src/test/kotlin/org/jetbrains/compose/reload/gradle/tests/RuntimeClasspathTest.kt
@@ -5,17 +5,24 @@
 
 package org.jetbrains.compose.reload.gradle.tests
 
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.compose.reload.core.HOT_RELOAD_VERSION
 import org.jetbrains.compose.reload.core.testFixtures.PathRegex
 import org.jetbrains.compose.reload.core.testFixtures.assertMatches
+import org.jetbrains.compose.reload.core.testFixtures.minus
 import org.jetbrains.compose.reload.core.testFixtures.regexEscaped
 import org.jetbrains.compose.reload.gradle.ComposeHotReloadPlugin
 import org.jetbrains.compose.reload.gradle.composeHotReloadAgentClasspath
 import org.jetbrains.compose.reload.gradle.composeHotReloadAgentJar
 import org.jetbrains.compose.reload.gradle.composeHotReloadRuntimeClasspath
+import org.jetbrains.compose.reload.gradle.kotlinJvmOrNull
+import org.jetbrains.compose.reload.gradle.utils.evaluate
 import org.jetbrains.compose.reload.gradle.utils.withRepositories
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.Test
+import kotlin.test.fail
 
 class RuntimeClasspathTest {
     @Test
@@ -46,6 +53,44 @@ class RuntimeClasspathTest {
             PathRegex(".*hot-reload-runtime-jvm-${HOT_RELOAD_VERSION.regexEscaped}.jar"),
             PathRegex(".*hot-reload-annotations-jvm-${HOT_RELOAD_VERSION.regexEscaped}.jar"),
             { true }
+        )
+    }
+
+    @Test
+    fun `test - agent classpath should not resolve kotlin stdlib`() {
+        val kotlinStdlib = PathRegex(".*stdlib.*")
+        val project = ProjectBuilder.builder().build()
+        project.withRepositories()
+
+        val kotlinStdlibFiles = project.composeHotReloadAgentClasspath.files.filter { file ->
+            kotlinStdlib.matches(file)
+        }
+
+        if (kotlinStdlibFiles.isNotEmpty()) {
+            fail("classpath should not resolve them in kotlin stdlib files: $kotlinStdlibFiles")
+        }
+    }
+
+    @ParameterizedTest(name = "Kotlin Version: {0}")
+    @ValueSource(strings = ["2.2.0", "2.2.20"])
+    fun `test - user defined kotlin-stdlib`(version: String) {
+        val project = ProjectBuilder.builder().build()
+        project.withRepositories()
+        project.plugins.apply("org.jetbrains.kotlin.jvm")
+        project.plugins.apply("org.jetbrains.compose")
+        project.plugins.apply("org.jetbrains.kotlin.plugin.compose")
+        project.plugins.apply(ComposeHotReloadPlugin::class.java)
+
+        project.dependencies {
+            "implementation"("org.jetbrains.kotlin:kotlin-stdlib:$version")
+        }
+
+        project.evaluate()
+
+        val main = project.kotlinJvmOrNull!!.target.compilations.getByName("main")
+        main.composeHotReloadRuntimeClasspath.assertMatches(
+            PathRegex(".*kotlin-stdlib-${Regex.escape(version)}.jar"),
+            (PathRegex(".*") - PathRegex(".*stdlib.*")) // everything, except any other kotlin-stdlib
         )
     }
 }

--- a/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/checkClasspath.kt
+++ b/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/checkClasspath.kt
@@ -38,7 +38,7 @@ internal fun checkClasspath(classpath: AppClasspath, composeVersion: TestedCompo
     }
 }
 
-private class DependencyFinder(private val groupId: String, private val artifactId: String) {
+private class DependencyFinder(groupId: String, artifactId: String) {
     private val regex = dependencyRegex(groupId, artifactId)
     fun findVersion(classpath: AppClasspath): String? {
         classpath.files.forEach { file ->

--- a/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/gradle/RuntimeDependenciesTest.kt
+++ b/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/gradle/RuntimeDependenciesTest.kt
@@ -186,7 +186,7 @@ private suspend fun HotReloadTestFixture.resolveRuntimeClasspath(projectPath: St
 
 
 private val stdlib = arrayOf(
-    PathRegex(".*annotations-13.0.jar"),
+    PathRegex(".*annotations-.*.jar"),
     PathRegex(".*kotlin-stdlib.*.jar"),
 )
 


### PR DESCRIPTION
The agent classpath is supposed to be part of the System ClassLoader of user applications. We resolve it as 'real classpath' (not shadowed), therefore we shall not resolve a kotlin-stdlib, but just rely on the user resolve stdlib.

Fixes #420