### PR TITLE
[runtime] Replace the use of `window.isActive` with `window.isVisible` in `startWindowManager`

### DIFF
--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/window.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/window.kt
@@ -69,7 +69,7 @@ internal fun startWindowManager(window: Window): WindowId {
             OrchestrationMessage.ApplicationWindowGone(windowId).sendAsync()
         }
 
-        if (window.isActive) {
+        if (window.isVisible) {
             broadcastActiveState()
         }
 
@@ -104,7 +104,11 @@ internal fun startWindowManager(window: Window): WindowId {
 
         val componentListener = object : ComponentAdapter() {
             fun broadcastIfActive() {
-                if (window.isActive) {
+                /**
+                 * `window.isActive` behaves inconsistently on Linux
+                 * Therefore we use `window.isVisible` to check if the window is active
+                 */
+                if (window.isVisible) {
                     broadcastActiveState()
                 }
             }


### PR DESCRIPTION
`window.isActive` causes issues on Linux, resulting in the window state being updated inconsistently