### PR TITLE
[properties] Add `visibility` field to parameters

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/compose/reload/build/tasks/GenerateHotReloadEnvironmentGradleExtensionsTask.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/compose/reload/build/tasks/GenerateHotReloadEnvironmentGradleExtensionsTask.kt
@@ -38,6 +38,8 @@ open class GenerateHotReloadEnvironmentGradleExtensionsTask : DefaultTask() {
             import org.jetbrains.compose.reload.core.HotReloadProperty
             import org.jetbrains.compose.reload.core.Os
             import org.jetbrains.compose.reload.InternalHotReloadApi
+            import org.jetbrains.compose.reload.DelicateHotReloadApi
+            import org.jetbrains.compose.reload.ExperimentalHotReloadApi
             
             {{element}}
         """.trimIndent().asTemplateOrThrow().renderOrThrow {
@@ -47,7 +49,7 @@ open class GenerateHotReloadEnvironmentGradleExtensionsTask : DefaultTask() {
                 * See [HotReloadProperty.{{name}}]
                 * {{documentation}}
                 */
-                {{visibility}} val Project.{{providerName}}: Provider<{{providerType}}> get() {
+                {{visibilityAnnotation}} val Project.{{providerName}}: Provider<{{providerType}}> get() {
                     {{providerStatement}} 
                 }
                 
@@ -55,7 +57,7 @@ open class GenerateHotReloadEnvironmentGradleExtensionsTask : DefaultTask() {
                 * See [HotReloadProperty.{{name}}]
                 * {{documentation}}
                 */
-                {{visibility}} val Project.{{propertyName}}: {{propertyType}} get() {
+                {{visibilityAnnotation}}val Project.{{propertyName}}: {{propertyType}} get() {
                     {{statement}} 
                 }
                 
@@ -67,7 +69,7 @@ open class GenerateHotReloadEnvironmentGradleExtensionsTask : DefaultTask() {
                 val providerName = "${propertyName}Provider"
 
                 "element"(elementTemplate.renderOrThrow {
-                    "visibility"("@InternalHotReloadApi")
+                    "visibilityAnnotation"(property.visibilityAnnotation.let { if (it.isNotBlank()) "$it " else "" })
                     "name"(property.name)
                     "propertyName"("composeReload${property.name.capitalized()}")
                     "providerName"(providerName)

--- a/hot-reload-core/api/hot-reload-core.api
+++ b/hot-reload-core/api/hot-reload-core.api
@@ -231,6 +231,84 @@ public final class org/jetbrains/compose/reload/core/FutureKt {
 	public static final fun toFuture (Ljava/util/concurrent/CompletableFuture;)Lorg/jetbrains/compose/reload/core/Future;
 }
 
+public final class org/jetbrains/compose/reload/core/HotReloadEnvironment {
+	public static final field INSTANCE Lorg/jetbrains/compose/reload/core/HotReloadEnvironment;
+	public final fun getDevToolsDetached ()Z
+	public final fun getDevToolsEnabled ()Z
+	public final fun getDevToolsIsHeadless ()Z
+	public final fun getDevToolsTransparencyEnabled ()Z
+	public final fun getGradleBuildContinuous ()Z
+	public final fun getGradleBuildOptimize ()Z
+	public final fun getGradleWarmupEnabled ()Z
+	public final fun getLogLevel ()Lorg/jetbrains/compose/reload/core/Logger$Level;
+	public final fun getLogStdout ()Z
+	public final fun getReloadEffectsEnabled ()Z
+	public final fun getStderrFile ()Ljava/nio/file/Path;
+	public final fun getStdinFile ()Ljava/nio/file/Path;
+	public final fun getStdoutFile ()Ljava/nio/file/Path;
+	public final fun isHotReloadActive ()Z
+}
+
+public final class org/jetbrains/compose/reload/core/HotReloadProperty : java/lang/Enum {
+	public static final field DevToolsDetached Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field DevToolsEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field DevToolsIsHeadless Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field DevToolsTransparencyEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field GradleBuildContinuous Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field GradleBuildOptimize Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field GradleWarmupEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field IsHotReloadActive Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field JetBrainsRuntimeBinary Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field JetBrainsRuntimeVersion Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field LogLevel Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field LogStdout Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field ReloadEffectsEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field StderrFile Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field StdinFile Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field StdoutFile Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public final fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getTargets ()Ljava/util/List;
+	public final fun getType ()Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public final fun getVisibility ()Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static fun values ()[Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+}
+
+public final class org/jetbrains/compose/reload/core/HotReloadProperty$Environment : java/lang/Enum {
+	public static final field Application Lorg/jetbrains/compose/reload/core/HotReloadProperty$Environment;
+	public static final field BuildTool Lorg/jetbrains/compose/reload/core/HotReloadProperty$Environment;
+	public static final field DevTools Lorg/jetbrains/compose/reload/core/HotReloadProperty$Environment;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/compose/reload/core/HotReloadProperty$Environment;
+	public static fun values ()[Lorg/jetbrains/compose/reload/core/HotReloadProperty$Environment;
+}
+
+public final class org/jetbrains/compose/reload/core/HotReloadProperty$Type : java/lang/Enum {
+	public static final field Boolean Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static final field Enum Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static final field File Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static final field Files Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static final field Int Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static final field Long Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static final field String Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+	public static fun values ()[Lorg/jetbrains/compose/reload/core/HotReloadProperty$Type;
+}
+
+public final class org/jetbrains/compose/reload/core/HotReloadProperty$Visibility : java/lang/Enum {
+	public static final field Delicate Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+	public static final field Deprecated Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+	public static final field Experimental Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+	public static final field Internal Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+	public static final field Public Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+	public static fun values ()[Lorg/jetbrains/compose/reload/core/HotReloadProperty$Visibility;
+}
+
 public final class org/jetbrains/compose/reload/core/KotlinxCoroutinesExtensionsKt {
 	public static final fun asChannel (Lorg/jetbrains/compose/reload/core/State;I)Lkotlinx/coroutines/channels/Channel;
 	public static synthetic fun asChannel$default (Lorg/jetbrains/compose/reload/core/State;IILjava/lang/Object;)Lkotlinx/coroutines/channels/Channel;

--- a/hot-reload-gradle-core/api/hot-reload-gradle-core.api
+++ b/hot-reload-gradle-core/api/hot-reload-gradle-core.api
@@ -7,6 +7,39 @@ public final class org/jetbrains/compose/reload/gradle/ComposeHotReloadRuntime {
 	public static final fun getComposeHotReloadRuntimeClasspath (Lorg/gradle/api/Project;)Lorg/gradle/api/file/FileCollection;
 }
 
+public final class org/jetbrains/compose/reload/gradle/HotReloadGradleEnvironmentKt {
+	public static final fun getComposeReloadDevToolsDetached (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadDevToolsDetachedProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadDevToolsEnabled (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadDevToolsEnabledProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadDevToolsIsHeadless (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadDevToolsIsHeadlessProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadDevToolsTransparencyEnabled (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadDevToolsTransparencyEnabledProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadGradleBuildContinuous (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadGradleBuildContinuousProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadGradleBuildOptimize (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadGradleBuildOptimizeProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadGradleWarmupEnabled (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadGradleWarmupEnabledProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadJetBrainsRuntimeBinary (Lorg/gradle/api/Project;)Ljava/nio/file/Path;
+	public static final fun getComposeReloadJetBrainsRuntimeBinaryProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadJetBrainsRuntimeVersion (Lorg/gradle/api/Project;)I
+	public static final fun getComposeReloadJetBrainsRuntimeVersionProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadLogLevel (Lorg/gradle/api/Project;)Lorg/jetbrains/compose/reload/core/Logger$Level;
+	public static final fun getComposeReloadLogLevelProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadLogStdout (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadLogStdoutProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadReloadEffectsEnabled (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadReloadEffectsEnabledProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadStderrFile (Lorg/gradle/api/Project;)Ljava/nio/file/Path;
+	public static final fun getComposeReloadStderrFileProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadStdinFile (Lorg/gradle/api/Project;)Ljava/nio/file/Path;
+	public static final fun getComposeReloadStdinFileProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadStdoutFile (Lorg/gradle/api/Project;)Ljava/nio/file/Path;
+	public static final fun getComposeReloadStdoutFileProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+}
+
 public final class org/jetbrains/compose/reload/gradle/HotReloadUsage {
 	public static final field COMPOSE_DEV_RUNTIME_USAGE Ljava/lang/String;
 	public static final field INSTANCE Lorg/jetbrains/compose/reload/gradle/HotReloadUsage;

--- a/properties.schema.json
+++ b/properties.schema.json
@@ -34,9 +34,12 @@
             "enum": ["build", "devtools", "application"]
           }
         },
-        "isDelicateApi": {
-          "type": "boolean",
-          "default": false
+        "visibility": {
+          "type": "string",
+          "enum": ["public", "delicate", "experimental", "internal", "deprecated"]
+        },
+        "deprecationMessage": {
+          "type": "string"
         },
         "documentation": {
           "type": "string"

--- a/properties.yaml
+++ b/properties.yaml
@@ -127,7 +127,7 @@ GradleBuildContinuous:
   type: boolean
   default: "false"
   target: [ application, devtools, build ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     - true: Compose Hot Reload will start a recompiler Gradle Daemon, which will continuously rebuilt/reload the project
     by watching all  inputs to the build
@@ -139,7 +139,7 @@ GradleWarmupEnabled:
   type: boolean
   default: "false"
   target: [ application, devtools, build ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     - true: Compose Hot Reload will launch a warmup recompile request when the application is started, to ensure that
     the recompiler Gradle daemon is running and ready to handle requests
@@ -150,7 +150,7 @@ GradleBuildOptimize:
   type: boolean
   default: "true"
   target: [ application, devtools, build ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     - true: Compose Hot Reload will try to optimize your build during hot reload 
     (e.g. by enabling Gradle's configuration cache during 'recompilation')
@@ -171,6 +171,7 @@ DevToolsEnabled:
   type: boolean
   default: "true"
   target: [ application, devtools, build ]
+  visibility: public
   documentation: |
     Flag to disable the 'devtools' application entirely
 
@@ -179,6 +180,7 @@ DevToolsIsHeadless:
   type: boolean
   default: "false"
   target: [ application, devtools, build ]
+  visibility: public
   documentation: |
     Run the dev tools in headless mode (No UI window shown)
 
@@ -196,7 +198,7 @@ DevToolsTransparencyEnabled:
   default: "(Os.currentOrNull() != Os.Linux).toString()"
   defaultIsExpression: true
   target: [ application, build, devtools ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     Some platforms might not be able to render transparency correctly (e.g. some linux environments).
     This property will allow such platforms to disable/enable transparency. This property is subject to change
@@ -207,6 +209,7 @@ DevToolsDetached:
   type: boolean
   default: "false"
   target: [ application, build, devtools ]
+  visibility: public
   documentation: |
     If enabled, dev tools window will be detached from the main application
 
@@ -215,6 +218,7 @@ ReloadEffectsEnabled:
   type: boolean
   default: "true"
   target: [ application, build ]
+  visibility: public
   documentation: |
     Enable reload effects that are shown in the UI when a reload is triggered.
 
@@ -243,7 +247,6 @@ SubprocessDebuggingEnabled:
   type: boolean
   default: "false"
   target: [ build ]
-  isDelicateApi: true
   documentation: |
     Enable this property to allow propagating the 'idea.debugger.dispatch.port' to all subprocesses.
     This is useful when debugging dev tools. Note: this may break the debugging of the user application if IJ is
@@ -253,7 +256,7 @@ JetBrainsRuntimeBinary:
   key: compose.reload.jbr.binary
   type: file
   target: [ build ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     The path to the 'JetBrainsRuntime' which shall be used when launching the app. 
     Note: This is a build-only property!
@@ -263,7 +266,7 @@ JetBrainsRuntimeVersion:
   type: int
   default: "21"
   target: [ build ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     Specifies the default 'JetBrains Runtime' version that shall be used (e.g. '21' or '25')
 
@@ -308,7 +311,7 @@ StdinFile:
   key: compose.reload.stdinFile
   type: file
   target: [ build, application, devtools ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     Used by 'async'/'non-blocking' launches of the application.
     Will point to the stdin file (can be pipe)
@@ -318,7 +321,7 @@ StdoutFile:
   key: compose.reload.stdoutFile
   type: file
   target: [ build, application, devtools ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     Used by 'async'/'non-blocking' launches of the application.
     Will point to a file where the stdout is supposed to be written to.
@@ -328,7 +331,7 @@ StderrFile:
   key: compose.reload.stderrFile
   type: file
   target: [ build, application, devtools ]
-  isDelicateApi: true
+  visibility: delicate
   documentation: |
     Used by 'async'/'non-blocking' launches of the application.
     Will point to a file where the stderr is supposed to be written to.
@@ -357,6 +360,7 @@ LogLevel:
   enumClass: org.jetbrains.compose.reload.core.Logger.Level
   target: [ application, devtools, build ]
   default: "Info"
+  visibility: public
   documentation: |
     Minimum logging level
 
@@ -365,6 +369,7 @@ LogStdout:
   type: boolean
   target: [ application, build, devtools ]
   default: "false"
+  visibility: public
   documentation: |
     Enable output of all logs into the standard output
 
@@ -373,6 +378,7 @@ IsHotReloadActive:
   type: boolean
   target: [ application ]
   default: "false"
+  visibility: public
   documentation: |
     Will be set to 'true' if the application is launched with Hot Reload and therefore can be used
     to detect if hot reload is 'active'


### PR DESCRIPTION
* Remove `@InternalHotReloadApi` from `HotReloadEnvironment` and `HotReloadProperty`, mark every individual property with a proper visibility annotation
* Add a separate `visibility` field in `properties.yaml`. Visibility has 5 possible values: public, delicate, experimental, internal, deprecated. Internal by default. You can add `deprecationMessage` when deprecating properties
* All generated code related to a property is marked with a corresponding annotation
* I decided to now change visibility of `ComposeHotReloadArgumentsBuilder`. In general it is not ideal that we have to manage properties in two separate places, but I don't know what is the best way to change that. At least now we will get deprecation warnings if we decide to deprecate one of the properties
* Add an explicit `isUserConfigurable` field to properties to differentiate the properties set by CHR from properties expected from the user. We need this field, because some of the properties are public, but not expected from the user (e.g. `IsHotReloadActive`)

Potential next step: 
We can use `HotReloadProperty` API on the IDE side to automatically generate UI for hot run configuration options. E.g. we can generate a field for each property with `visibility == Visibility.Public` and `isUserConfigurable == true`