### PR TITLE
Use isolated project access API

### DIFF
--- a/hot-reload-core/api/hot-reload-core.api
+++ b/hot-reload-core/api/hot-reload-core.api
@@ -240,6 +240,7 @@ public final class org/jetbrains/compose/reload/core/HotReloadEnvironment {
 	public final fun getGradleBuildContinuous ()Z
 	public final fun getGradleBuildOptimize ()Z
 	public final fun getGradleWarmupEnabled ()Z
+	public final fun getIsolatedProjectsEnabled ()Z
 	public final fun getLogLevel ()Lorg/jetbrains/compose/reload/core/Logger$Level;
 	public final fun getLogStdout ()Z
 	public final fun getReloadEffectsEnabled ()Z
@@ -258,6 +259,7 @@ public final class org/jetbrains/compose/reload/core/HotReloadProperty : java/la
 	public static final field GradleBuildOptimize Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field GradleWarmupEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field IsHotReloadActive Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field IsolatedProjectsEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field JetBrainsRuntimeBinary Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field JetBrainsRuntimeVersion Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field LogLevel Lorg/jetbrains/compose/reload/core/HotReloadProperty;

--- a/hot-reload-gradle-core/api/hot-reload-gradle-core.api
+++ b/hot-reload-gradle-core/api/hot-reload-gradle-core.api
@@ -22,6 +22,8 @@ public final class org/jetbrains/compose/reload/gradle/HotReloadGradleEnvironmen
 	public static final fun getComposeReloadGradleBuildOptimizeProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
 	public static final fun getComposeReloadGradleWarmupEnabled (Lorg/gradle/api/Project;)Z
 	public static final fun getComposeReloadGradleWarmupEnabledProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadIsolatedProjectsEnabled (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadIsolatedProjectsEnabledProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
 	public static final fun getComposeReloadJetBrainsRuntimeBinary (Lorg/gradle/api/Project;)Ljava/nio/file/Path;
 	public static final fun getComposeReloadJetBrainsRuntimeBinaryProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
 	public static final fun getComposeReloadJetBrainsRuntimeVersion (Lorg/gradle/api/Project;)I

--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/arguments.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/arguments.kt
@@ -92,7 +92,7 @@ fun Project.createComposeHotReloadArguments(builder: ComposeHotReloadArgumentsBu
 internal class ComposeHotReloadArguments(project: Project) :
     ComposeHotReloadArgumentsBuilder,
     CommandLineArgumentProvider {
-    private val rootProjectDir = project.isolated.rootProject.projectDirectory
+    private val rootProjectDir = project.rootProjectDirectory
     private val projectPath = project.path
 
     @field:Transient
@@ -331,7 +331,7 @@ internal class ComposeHotReloadArguments(project: Project) :
 
         /* Provide "recompiler" properties */
         add("-D${HotReloadProperty.BuildSystem.key}=${BuildSystem.Gradle.name}")
-        add("-D${HotReloadProperty.GradleBuildRoot.key}=${rootProjectDir.asFile.absolutePath}")
+        add("-D${HotReloadProperty.GradleBuildRoot.key}=${rootProjectDir.absolutePath}")
         add("-D${HotReloadProperty.GradleBuildProject.key}=$projectPath")
         if (reloadTaskName.isPresent) {
             add("-D${HotReloadProperty.GradleBuildTask.key}=${reloadTaskName.get()}")

--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotReloadTasks.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotReloadTasks.kt
@@ -78,7 +78,7 @@ internal val KotlinCompilation<*>.hotReloadTask: Future<TaskProvider<ComposeHotR
 @DisableCachingByDefault(because = "Should always run")
 @InternalHotReloadApi
 abstract class ComposeHotReloadTask : DefaultTask(), ComposeHotReloadOtherTask {
-    private val rootProjectDirectory = project.isolated.rootProject.projectDirectory
+    private val rootProjectDirectory = project.rootProjectDirectory
 
     @get:Internal
     val agentPort: Property<Int> = project.objects.property<Int>()
@@ -119,7 +119,7 @@ abstract class ComposeHotReloadTask : DefaultTask(), ComposeHotReloadOtherTask {
 
 
     private fun reloadReport(request: ReloadClassesRequest): String {
-        val rootPath = rootProjectDirectory.asFile
+        val rootPath = rootProjectDirectory
         val entries = request.changedClassFiles.entries.toTypedArray()
 
         return """

--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/projectExtensions.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/projectExtensions.kt
@@ -1,0 +1,13 @@
+package org.jetbrains.compose.reload.gradle
+
+import org.gradle.api.Project
+import java.io.File
+
+internal val Project.rootProjectDirectory: File
+    get() {
+        return if (composeReloadIsolatedProjectsEnabled) {
+            project.isolated.rootProject.projectDirectory.asFile
+        } else {
+            rootProject.projectDir
+        }
+    }

--- a/properties.yaml
+++ b/properties.yaml
@@ -382,3 +382,13 @@ IsHotReloadActive:
   documentation: |
     Will be set to 'true' if the application is launched with Hot Reload and therefore can be used
     to detect if hot reload is 'active'
+
+IsolatedProjectsEnabled:
+  key: compose.reload.isolatedProjectsEnabled
+  type: boolean
+  target: [ application, build, devtools ]
+  default: "false"
+  visibility: public
+  documentation: |
+    Enables support for Gradle's incubating 'isolated projects' feature
+


### PR DESCRIPTION
Using the isolated project access API is required for compatibility with Gradle's configuration caching.