### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ You can run these Gradle tasks from the command line:
 
 ```shell
 ./gradlew :app:hotRunJvm
+# or
+./gradlew :composeApp:hotRunJvm
 ```
 
 After making changes, save all files to automatically update your app's UI.


### PR DESCRIPTION
by default KMP plugin creates a project with "composeApp" name, using "app" in the documentation can be misleading. added an example with `composeApp`. other section may require update too.