### PR TITLE
Recompiler: Enable IC for KMP

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompiler.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompiler.kt
@@ -113,7 +113,9 @@ internal class GradleRecompiler(
                     "--configuration-cache".takeIf { HotReloadEnvironment.gradleBuildOptimize },
                     "--configuration-cache-problems=warn".takeIf { HotReloadEnvironment.gradleBuildOptimize },
                     "--build-cache".takeIf { HotReloadEnvironment.gradleBuildOptimize },
-                    "--parallel".takeIf { HotReloadEnvironment.gradleBuildOptimize }
+                    "--parallel".takeIf { HotReloadEnvironment.gradleBuildOptimize },
+                    "-Pkotlin.internal.incremental.enableUnsafeOptimizationsForMultiplatform=true"
+                        .takeIf { HotReloadEnvironment.gradleBuildOptimize }
                 )
             )
         }


### PR DESCRIPTION
The property has a significant impact on build times. There are some known 'unsafe' issues, e.g., the following code.

```
// common
// FILE: A.kt
fun foo(x: Any) = 10
// FILE: B.kt
fun main() {
   println(foo(1))
}
// platform
// FILE: C.kt
fun foo(x: Int) = 20
```

Would print either 10 or 20, depending on which of A.kt and C.kt is clean.

Such cases, while not ideal for 'real builds,' are not necessarily deal-breakers for trusting hot reload as a tool.