### PR TITLE
Introduce AllDirty mode for statics (top level vals) re-initialization

### DIFF
--- a/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/reload.kt
+++ b/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/reload.kt
@@ -118,7 +118,7 @@ internal fun Context.reload(
     instrumentation.redefineClasses(*definitions.toTypedArray())
     return redefineApplicationInfo().get().mapLeft { redefinition ->
         val reload = Reload(reloadRequestId, definitions, redefinition)
-        reinitializeStaticsIfNecessary(reload)
+        reinitializeStaticsIfNecessary(reload, instrumentation)
         cleanResourceCacheIfNecessary()
         reload
     }

--- a/hot-reload-core/api/hot-reload-core.api
+++ b/hot-reload-core/api/hot-reload-core.api
@@ -244,6 +244,7 @@ public final class org/jetbrains/compose/reload/core/HotReloadEnvironment {
 	public final fun getLogLevel ()Lorg/jetbrains/compose/reload/core/Logger$Level;
 	public final fun getLogStdout ()Z
 	public final fun getReloadEffectsEnabled ()Z
+	public final fun getStaticsReinitializeMode ()Lorg/jetbrains/compose/reload/core/StaticsReinitializeMode;
 	public final fun getStderrFile ()Ljava/nio/file/Path;
 	public final fun getStdinFile ()Ljava/nio/file/Path;
 	public final fun getStdoutFile ()Ljava/nio/file/Path;
@@ -265,6 +266,7 @@ public final class org/jetbrains/compose/reload/core/HotReloadProperty : java/la
 	public static final field LogLevel Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field LogStdout Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field ReloadEffectsEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field StaticsReinitializeMode Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field StderrFile Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field StdinFile Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field StdoutFile Lorg/jetbrains/compose/reload/core/HotReloadProperty;

--- a/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/StaticsReinitializeMode.kt
+++ b/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/StaticsReinitializeMode.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.core
+
+import org.jetbrains.compose.reload.InternalHotReloadApi
+
+@InternalHotReloadApi
+public enum class StaticsReinitializeMode {
+    ChangedOnly, AllDirty
+}

--- a/properties.yaml
+++ b/properties.yaml
@@ -391,3 +391,16 @@ IsolatedProjectsEnabled:
   visibility: deprecated
   documentation: |
     Enables support for Gradle's incubating 'isolated projects' feature
+
+StaticsReinitializeMode:
+  key: compose.reload.staticsReinitializeMode
+  type: enum
+  enumClass: org.jetbrains.compose.reload.core.StaticsReinitializeMode
+  target: [ application ]
+  default: "ChangedOnly"
+  visibility: experimental
+  documentation: |
+    Sets the mode for statics re-initialization. 
+    When "AllDirty" is set, all static initializers that are recognized as dirty (affected by changes) 
+    will be re-invoked on reload.
+    When "ChangedOnly" is set, only statics of changed classes will be re-initialized.

--- a/tests/src/reloadUnitTest/kotlin/tests/statics.kt
+++ b/tests/src/reloadUnitTest/kotlin/tests/statics.kt
@@ -5,6 +5,8 @@
 
 package tests
 
+import org.jetbrains.compose.reload.core.HotReloadProperty
+import org.jetbrains.compose.reload.core.StaticsReinitializeMode
 import org.jetbrains.compose.reload.test.HotReloadUnitTest
 import org.jetbrains.compose.reload.test.compileAndReload
 import kotlin.test.assertEquals
@@ -34,4 +36,34 @@ fun `test - change top level property`() {
     """.trimIndent()
     )
     assertEquals("bar", topLevelProperty)
+}
+
+private fun changeInitializer() {
+    assertEquals("foo", topLevelProperty2)
+    compileAndReload(
+        """
+        package tests
+        object StaticsObject {
+            val property = "bar"
+        }
+    """.trimIndent()
+    )
+}
+
+private fun setStaticsReinitializeMode(mode: StaticsReinitializeMode) {
+    System.setProperty(HotReloadProperty.StaticsReinitializeMode.key, mode.name)
+}
+
+@HotReloadUnitTest
+fun `test - change initializer of top level property (ChangedOnly mode)`() {
+    setStaticsReinitializeMode(StaticsReinitializeMode.ChangedOnly)
+    changeInitializer()
+    assertEquals("foo", topLevelProperty2)
+}
+
+@HotReloadUnitTest
+fun `test - change initializer of top level property (AllDirty mode)`() {
+    setStaticsReinitializeMode(StaticsReinitializeMode.AllDirty)
+    changeInitializer()
+    assertEquals("bar", topLevelProperty2)
 }

--- a/tests/src/reloadUnitTest/kotlin/tests/statics.topLevelProperty2.kt
+++ b/tests/src/reloadUnitTest/kotlin/tests/statics.topLevelProperty2.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+@file:JvmName("staticsTopLevelProperty2")
+
+package tests
+
+val topLevelProperty2 = StaticsObject.property


### PR DESCRIPTION
When "AllDirty" is set, all static initializers that are recognized as dirty (affected by changes) will be re-invoked on reload. Previously, only statics of changed classes were re-initialized ("ChangedOnly" mode).

Fixes: #230

Test: test added to statics.kt of reloadUnitTest. KotlinConfApp is manually tested