### PR TITLE
[runtime] memory optimisations

### DIFF
--- a/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/compose.kt
+++ b/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/compose.kt
@@ -71,7 +71,7 @@ private fun launchComposeGroupInvalidation() {
             .filter { scope -> scope.group != null }
             .groupBy { it.group }
 
-        invalidations.forEach { group, scopes ->
+        invalidations.forEach { (group, scopes) ->
             if (group == null) return@forEach
 
             val methods = scopes.map { it.methodId }.toSet()

--- a/hot-reload-analysis/api/hot-reload-analysis.api
+++ b/hot-reload-analysis/api/hot-reload-analysis.api
@@ -662,8 +662,8 @@ public final class org/jetbrains/compose/reload/analysis/ScopeInfo {
 	public final fun component2 ()Lorg/jetbrains/compose/reload/analysis/ScopeType;
 	public final fun component3-hC-z0cA ()J
 	public final fun component4-z2uEmV4 ()Lorg/jetbrains/compose/reload/analysis/ComposeGroupKey;
-	public final fun component5 ()Ljava/util/Set;
-	public final fun component6 ()Ljava/util/Set;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Lorg/jetbrains/compose/reload/core/Context;
 	public final fun component9 ()Lorg/jetbrains/compose/reload/analysis/ScopeInfo$SourceLocation;
@@ -671,8 +671,10 @@ public final class org/jetbrains/compose/reload/analysis/ScopeInfo {
 	public final fun getChildren ()Ljava/util/List;
 	public final fun getExtras ()Lorg/jetbrains/compose/reload/core/Context;
 	public final fun getFieldDependencies ()Ljava/util/Set;
+	public final fun getFieldDependenciesList ()Ljava/util/List;
 	public final fun getGroup-z2uEmV4 ()Lorg/jetbrains/compose/reload/analysis/ComposeGroupKey;
 	public final fun getMethodDependencies ()Ljava/util/Set;
+	public final fun getMethodDependenciesList ()Ljava/util/List;
 	public final fun getMethodId ()Lorg/jetbrains/compose/reload/analysis/MethodId;
 	public final fun getScopeHash-hC-z0cA ()J
 	public final fun getScopeType ()Lorg/jetbrains/compose/reload/analysis/ScopeType;

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ClassId.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ClassId.kt
@@ -36,8 +36,8 @@ value class ClassId(val value: String) : Comparable<ClassId> {
     fun toFqn(): String = value.replace("/", ".")
 
     companion object {
-        fun fromFqn(fqn: String): ClassId = ClassId(fqn.replace(".", "/"))
-        fun fromDesc(desc: String): ClassId = ClassId(desc.removePrefix("L").removeSuffix(";"))
+        fun fromFqn(fqn: String): ClassId = ClassId(fqn.replace(".", "/").interned())
+        fun fromDesc(desc: String): ClassId = ClassId(desc.removePrefix("L").removeSuffix(";").interned())
     }
 }
 
@@ -46,7 +46,7 @@ fun ClassId(clazz: KClass<*>): ClassId {
 }
 
 fun ClassId(clazz: Class<*>): ClassId {
-    return clazz.name.replace(".", "/").let(::ClassId)
+    return clazz.name.replace(".", "/").interned().let(::ClassId)
 }
 
 inline val Class<*>.classId: ClassId

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ClassInfo.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ClassInfo.kt
@@ -42,16 +42,16 @@ fun ClassInfo(classNode: ClassNode): ClassInfo? {
                 else -> MethodInfo.Modality.OPEN
             }
         )
-    }.associateBy { it.methodId }
+    }.associateByTo(hashMapOf()) { it.methodId }.toReadOnlyHashMap()
 
-    val fields = classNode.fields.associate { fieldNode ->
+    val fields = classNode.fields.associateTo(hashMapOf()) { fieldNode ->
         FieldId(classNode, fieldNode) to FieldInfo(
             fieldId = FieldId(classNode, fieldNode),
             isStatic = fieldNode.access and (Opcodes.ACC_STATIC) != 0,
             initialValue = fieldNode.value,
             additionalChangeIndicatorHash = getResourceContentHash(fieldNode)
         )
-    }
+    }.toReadOnlyHashMap()
 
     return ClassInfo(
         classId = classId,

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/Interner.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/Interner.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.analysis
+
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.collections.set
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+private class Interner<T> {
+    private val lock = ReentrantReadWriteLock()
+    private val map = WeakHashMap<T, WeakReference<T>>()
+
+    fun intern(value: T): T {
+        val existing = lock.read { map[value]?.get() }
+        if (existing != null) return existing
+
+        return lock.write {
+            /* Check that the value was not added while we waited for the write lock */
+            val added = map[value]?.get()
+            if (added != null) return@write added
+
+            map[value] = WeakReference(value)
+            value
+        }
+    }
+}
+
+private val StringInterner = Interner<String>()
+
+internal fun String.interned(): String = StringInterner.intern(this)

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ScopeInfo.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/ScopeInfo.kt
@@ -17,12 +17,18 @@ data class ScopeInfo @InternalHotReloadApi internal constructor(
     val scopeType: ScopeType,
     val scopeHash: ScopeHash,
     val group: ComposeGroupKey?,
-    val methodDependencies: Set<MethodId>,
-    val fieldDependencies: Set<FieldId>,
+    val methodDependenciesList: List<MethodId>,
+    val fieldDependenciesList: List<FieldId>,
     val children: List<ScopeInfo>,
     val extras: Context,
     val sourceLocation: SourceLocation,
 ) {
+    @Deprecated("Use methodDependenciesList instead", ReplaceWith("methodDependenciesList"))
+    val methodDependencies: Set<MethodId> get() = methodDependenciesList.toSet()
+
+    @Deprecated("Use fieldDependenciesList instead", ReplaceWith("fieldDependenciesList"))
+    val fieldDependencies: Set<FieldId> get() = fieldDependenciesList.toSet()
+
     @ConsistentCopyVisibility
     data class SourceLocation @InternalHotReloadApi internal constructor(
         val sourceFile: String?,
@@ -55,12 +61,12 @@ internal fun createScopeInfo(
         scopeType = tree.type,
         scopeHash = tree.scopeHash(methodNode),
         group = tree.group,
-        methodDependencies = tree.methodDependencies(),
-        fieldDependencies = tree.fieldDependencies(),
-        children = tree.children.map { child -> createScopeInfo(methodId, methodNode, child, sourceFile) },
+        methodDependenciesList = tree.methodDependencies(),
+        fieldDependenciesList = tree.fieldDependencies(),
+        children = tree.children.map { child -> createScopeInfo(methodId, methodNode, child, sourceFile) }.toList(),
         extras = createScopeInfoExtras(methodId, methodNode, tree),
         sourceLocation = SourceLocation(
-            sourceFile = sourceFile,
+            sourceFile = sourceFile?.interned(),
             firstLineNumber = tree.tokens.firstLineNumber,
         )
     )

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/asmUtils.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/asmUtils.kt
@@ -23,7 +23,7 @@ import org.objectweb.asm.tree.LdcInsnNode
 import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
 
-fun ClassId(node: ClassNode): ClassId = ClassId(node.name)
+fun ClassId(node: ClassNode): ClassId = ClassId(node.name.interned())
 
 internal fun AbstractInsnNode.intValueOrNull(): Int? {
     if (this is LdcInsnNode) return this.cst as? Int
@@ -74,38 +74,38 @@ fun ClassId(bytecode: ByteArray): ClassId? {
         }
     }, SKIP_CODE and SKIP_FRAMES and ClassReader.SKIP_DEBUG)
 
-    return className?.let { name -> ClassId(name) }
+    return className?.let { name -> ClassId(name.interned()) }
 }
 
 
 internal fun MethodId(classNode: ClassNode, methodNode: MethodNode): MethodId = MethodId(
     classId = ClassId(classNode),
-    methodName = methodNode.name,
-    methodDescriptor = methodNode.desc,
+    methodName = methodNode.name.interned(),
+    methodDescriptor = methodNode.desc.interned(),
 )
 
 internal fun MethodId(handle: Handle) = MethodId(
-    classId = ClassId(handle.owner),
-    methodName = handle.name,
-    methodDescriptor = handle.desc
+    classId = ClassId(handle.owner.interned()),
+    methodName = handle.name.interned(),
+    methodDescriptor = handle.desc.interned()
 )
 
 internal fun MethodId(methodInsnNode: MethodInsnNode): MethodId = MethodId(
-    classId = ClassId(methodInsnNode.owner),
-    methodName = methodInsnNode.name,
-    methodDescriptor = methodInsnNode.desc
+    classId = ClassId(methodInsnNode.owner.interned()),
+    methodName = methodInsnNode.name.interned(),
+    methodDescriptor = methodInsnNode.desc.interned()
 )
 
 internal fun FieldId(fieldIsnNode: FieldInsnNode): FieldId = FieldId(
-    classId = ClassId(fieldIsnNode.owner),
-    fieldName = fieldIsnNode.name,
-    fieldDescriptor = fieldIsnNode.desc
+    classId = ClassId(fieldIsnNode.owner.interned()),
+    fieldName = fieldIsnNode.name.interned(),
+    fieldDescriptor = fieldIsnNode.desc.interned()
 )
 
 internal fun FieldId(classNode: ClassNode, fieldNode: FieldNode): FieldId = FieldId(
     classId = ClassId(classNode),
-    fieldName = fieldNode.name,
-    fieldDescriptor = fieldNode.desc
+    fieldName = fieldNode.name.interned(),
+    fieldDescriptor = fieldNode.desc.interned()
 )
 
 internal val MethodNode.allAnnotations: List<AnnotationNode>

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/render.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/render.kt
@@ -37,12 +37,21 @@ fun ClassInfo.render(): String = buildString {
     appendLine("$classId {")
 
     if (fields.isNotEmpty()) {
-        appendLine(fields.values.joinToString("\n") { it.render() }.indent())
+        appendLine(
+            fields.values
+                .sortedWith { f1, f2 -> f1.fieldId.compareTo(f2.fieldId) }
+                .joinToString("\n") { it.render() }
+                .indent()
+        )
         appendLine()
     }
 
     withIndent {
-        appendLine(methods.values.joinToString("\n\n") { it.render() })
+        appendLine(
+            methods.values
+                .sortedWith { m1, m2 -> m1.methodId.compareTo(m2.methodId) }
+                .joinToString("\n\n") { it.render() }
+        )
     }
 
 
@@ -70,22 +79,22 @@ internal fun ScopeInfo.render(): String = buildString {
     withIndent {
         appendLine("key: ${group?.key}")
         appendLine("codeHash: ${scopeHash.value}")
-        if (methodDependencies.isEmpty()) {
+        if (methodDependenciesList.isEmpty()) {
             appendLine("methodDependencies: []")
         } else {
             appendLine("methodDependencies: [")
             withIndent {
-                append(methodDependencies.joinToString(",\n"))
+                append(methodDependenciesList.joinToString(",\n"))
             }
             appendLine("]")
         }
 
-        if (fieldDependencies.isEmpty()) {
+        if (fieldDependenciesList.isEmpty()) {
             appendLine("fieldDependencies: []")
         } else {
             appendLine("fieldDependencies: [")
             withIndent {
-                append(fieldDependencies.joinToString(",\n"))
+                append(fieldDependenciesList.joinToString(",\n"))
             }
             appendLine("]")
         }
@@ -221,3 +230,11 @@ internal fun StringBuilder.withIndent(builder: StringBuilder.() -> Unit) {
 }
 
 internal fun String.indent(n: Int = 1) = prependIndent("    ".repeat(n))
+
+internal fun FieldId.compareTo(other: FieldId): Int {
+    return compareValuesBy(this, other, { it.fieldName }, { it.fieldDescriptor })
+}
+
+internal fun MethodId.compareTo(other: MethodId): Int {
+    return compareValuesBy(this, other, { it.methodName }, { it.methodDescriptor })
+}

--- a/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/utils.kt
+++ b/hot-reload-analysis/src/main/kotlin/org/jetbrains/compose/reload/analysis/utils.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.compose.reload.analysis
 
 import java.nio.ByteBuffer
+import java.util.Collections.singletonMap
 import java.util.zip.Checksum
 
 internal fun Checksum.updateBoolean(value: Boolean) {
@@ -36,3 +37,11 @@ internal fun Checksum.updateString(value: String) {
     updateInt(value.length)
     update(value.encodeToByteArray())
 }
+
+internal fun <K, V> HashMap<K, V>.toReadOnlyHashMap(): Map<K, V> = when (size) {
+    0 -> emptyMap()
+    1 -> entries.first().let { singletonMap(it.key, it.value) }
+    else -> this
+}
+
+internal fun <K, V> Map<K, V>.toHashMap(): HashMap<K, V> = HashMap(this)

--- a/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - higher order composable/application-info.txt
+++ b/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - higher order composable/application-info.txt
@@ -25,6 +25,24 @@ ComposableSingletons$FooKt {
     val INSTANCE: LComposableSingletons$FooKt;
     val lambda$-1435676418: Lkotlin/jvm/functions/Function2;
 
+    <clinit> {
+        desc: ()V
+        type: Regular
+        Method {
+            key: null
+            codeHash: 2631766068
+            methodDependencies: [
+                ComposableSingletons$FooKt.<init> ()V
+            ]
+            fieldDependencies: [
+                ComposableSingletons$FooKt$lambda$-1435676418$1.INSTANCE LComposableSingletons$FooKt$lambda$-1435676418$1;,
+                ComposableSingletons$FooKt.INSTANCE LComposableSingletons$FooKt;,
+                ComposableSingletons$FooKt.lambda$-1435676418 Lkotlin/jvm/functions/Function2;
+            ]
+        }
+    }
+    
+    
     <init> {
         desc: ()V
         type: Regular
@@ -49,29 +67,27 @@ ComposableSingletons$FooKt {
             ]
         }
     }
-    
-    
-    <clinit> {
-        desc: ()V
-        type: Regular
-        Method {
-            key: null
-            codeHash: 2631766068
-            methodDependencies: [
-                ComposableSingletons$FooKt.<init> ()V
-            ]
-            fieldDependencies: [
-                ComposableSingletons$FooKt.INSTANCE LComposableSingletons$FooKt;,
-                ComposableSingletons$FooKt$lambda$-1435676418$1.INSTANCE LComposableSingletons$FooKt$lambda$-1435676418$1;,
-                ComposableSingletons$FooKt.lambda$-1435676418 Lkotlin/jvm/functions/Function2;
-            ]
-        }
-    }
 }
 
 ComposableSingletons$FooKt$lambda$-1435676418$1 {
     val INSTANCE: LComposableSingletons$FooKt$lambda$-1435676418$1;
 
+    <clinit> {
+        desc: ()V
+        type: Regular
+        Method {
+            key: null
+            codeHash: 385586306
+            methodDependencies: [
+                ComposableSingletons$FooKt$lambda$-1435676418$1.<init> ()V
+            ]
+            fieldDependencies: [
+                ComposableSingletons$FooKt$lambda$-1435676418$1.INSTANCE LComposableSingletons$FooKt$lambda$-1435676418$1;
+            ]
+        }
+    }
+    
+    
     <init> {
         desc: ()V
         type: Regular
@@ -108,22 +124,6 @@ ComposableSingletons$FooKt$lambda$-1435676418$1 {
             fieldDependencies: []
         }
     }
-    
-    
-    <clinit> {
-        desc: ()V
-        type: Regular
-        Method {
-            key: null
-            codeHash: 385586306
-            methodDependencies: [
-                ComposableSingletons$FooKt$lambda$-1435676418$1.<init> ()V
-            ]
-            fieldDependencies: [
-                ComposableSingletons$FooKt$lambda$-1435676418$1.INSTANCE LComposableSingletons$FooKt$lambda$-1435676418$1;
-            ]
-        }
-    }
 }
 
 FooKt {
@@ -148,6 +148,20 @@ FooKt {
     }
     
     
+    Bar$lambda$0 {
+        desc: (Lkotlin/jvm/functions/Function2;ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+        type: Composable
+        Method {
+            key: null
+            codeHash: 4235434057
+            methodDependencies: [
+                FooKt.Bar (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+            ]
+            fieldDependencies: []
+        }
+    }
+    
+    
     Foo {
         desc: (Landroidx/compose/runtime/Composer;I)V
         type: Composable
@@ -163,27 +177,13 @@ FooKt {
                 key: -965539098
                 codeHash: 3015966053
                 methodDependencies: [
-                    ComposableSingletons$FooKt.getLambda$-1435676418$testModule ()Lkotlin/jvm/functions/Function2;,
-                    FooKt.Bar (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+                    FooKt.Bar (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V,
+                    ComposableSingletons$FooKt.getLambda$-1435676418$testModule ()Lkotlin/jvm/functions/Function2;
                 ]
                 fieldDependencies: [
                     ComposableSingletons$FooKt.INSTANCE LComposableSingletons$FooKt;
                 ]
             }
-        }
-    }
-    
-    
-    Bar$lambda$0 {
-        desc: (Lkotlin/jvm/functions/Function2;ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
-        type: Composable
-        Method {
-            key: null
-            codeHash: 4235434057
-            methodDependencies: [
-                FooKt.Bar (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-            ]
-            fieldDependencies: []
         }
     }
     

--- a/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - member field access/application-info.txt
+++ b/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - member field access/application-info.txt
@@ -21,9 +21,21 @@ fun Foo() {
 */
 
 Bar {
-    val x: I
     val $stable: I
+    val x: I
 
+    <clinit> {
+        desc: ()V
+        type: Regular
+        Method {
+            key: null
+            codeHash: 2636274694
+            methodDependencies: []
+            fieldDependencies: []
+        }
+    }
+    
+    
     <init> {
         desc: ()V
         type: Regular
@@ -50,30 +62,20 @@ Bar {
             ]
         }
     }
-    
-    
-    <clinit> {
-        desc: ()V
-        type: Regular
-        Method {
-            key: null
-            codeHash: 2636274694
-            methodDependencies: []
-            fieldDependencies: []
-        }
-    }
 }
 
 FooKt {
     val bar: LBar;
 
-    getBar {
-        desc: ()LBar;
+    <clinit> {
+        desc: ()V
         type: Regular
         Method {
             key: null
-            codeHash: 886555225
-            methodDependencies: []
+            codeHash: 1891533309
+            methodDependencies: [
+                Bar.<init> ()V
+            ]
             fieldDependencies: [
                 FooKt.bar LBar;
             ]
@@ -127,15 +129,13 @@ FooKt {
     }
     
     
-    <clinit> {
-        desc: ()V
+    getBar {
+        desc: ()LBar;
         type: Regular
         Method {
             key: null
-            codeHash: 1891533309
-            methodDependencies: [
-                Bar.<init> ()V
-            ]
+            codeHash: 886555225
+            methodDependencies: []
             fieldDependencies: [
                 FooKt.bar LBar;
             ]

--- a/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - method hash is the same when adding a Composable function above/application-info-modified.txt
+++ b/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - method hash is the same when adding a Composable function above/application-info-modified.txt
@@ -40,6 +40,20 @@ FooKt {
     }
     
     
+    Decoy$lambda$0 {
+        desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+        type: Composable
+        Method {
+            key: null
+            codeHash: 3619622796
+            methodDependencies: [
+                FooKt.Decoy (Landroidx/compose/runtime/Composer;I)V
+            ]
+            fieldDependencies: []
+        }
+    }
+    
+    
     Foo {
         desc: (Landroidx/compose/runtime/Composer;I)V
         type: Composable
@@ -57,20 +71,6 @@ FooKt {
                 methodDependencies: []
                 fieldDependencies: []
             }
-        }
-    }
-    
-    
-    Decoy$lambda$0 {
-        desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
-        type: Composable
-        Method {
-            key: null
-            codeHash: 3619622796
-            methodDependencies: [
-                FooKt.Decoy (Landroidx/compose/runtime/Composer;I)V
-            ]
-            fieldDependencies: []
         }
     }
     

--- a/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - nested card/application-info.txt
+++ b/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - nested card/application-info.txt
@@ -29,6 +29,26 @@ ComposableSingletons$FooKt {
     val lambda$1969856002: Lkotlin/jvm/functions/Function3;
     val lambda$904522804: Lkotlin/jvm/functions/Function3;
 
+    <clinit> {
+        desc: ()V
+        type: Regular
+        Method {
+            key: null
+            codeHash: 2144001912
+            methodDependencies: [
+                ComposableSingletons$FooKt.<init> ()V
+            ]
+            fieldDependencies: [
+                ComposableSingletons$FooKt.lambda$1969856002 Lkotlin/jvm/functions/Function3;,
+                ComposableSingletons$FooKt$lambda$904522804$1.INSTANCE LComposableSingletons$FooKt$lambda$904522804$1;,
+                ComposableSingletons$FooKt.lambda$904522804 Lkotlin/jvm/functions/Function3;,
+                ComposableSingletons$FooKt.INSTANCE LComposableSingletons$FooKt;,
+                ComposableSingletons$FooKt$lambda$1969856002$1.INSTANCE LComposableSingletons$FooKt$lambda$1969856002$1;
+            ]
+        }
+    }
+    
+    
     <init> {
         desc: ()V
         type: Regular
@@ -67,31 +87,27 @@ ComposableSingletons$FooKt {
             ]
         }
     }
-    
-    
-    <clinit> {
-        desc: ()V
-        type: Regular
-        Method {
-            key: null
-            codeHash: 2144001912
-            methodDependencies: [
-                ComposableSingletons$FooKt.<init> ()V
-            ]
-            fieldDependencies: [
-                ComposableSingletons$FooKt.INSTANCE LComposableSingletons$FooKt;,
-                ComposableSingletons$FooKt$lambda$1969856002$1.INSTANCE LComposableSingletons$FooKt$lambda$1969856002$1;,
-                ComposableSingletons$FooKt.lambda$1969856002 Lkotlin/jvm/functions/Function3;,
-                ComposableSingletons$FooKt$lambda$904522804$1.INSTANCE LComposableSingletons$FooKt$lambda$904522804$1;,
-                ComposableSingletons$FooKt.lambda$904522804 Lkotlin/jvm/functions/Function3;
-            ]
-        }
-    }
 }
 
 ComposableSingletons$FooKt$lambda$1969856002$1 {
     val INSTANCE: LComposableSingletons$FooKt$lambda$1969856002$1;
 
+    <clinit> {
+        desc: ()V
+        type: Regular
+        Method {
+            key: null
+            codeHash: 2164608135
+            methodDependencies: [
+                ComposableSingletons$FooKt$lambda$1969856002$1.<init> ()V
+            ]
+            fieldDependencies: [
+                ComposableSingletons$FooKt$lambda$1969856002$1.INSTANCE LComposableSingletons$FooKt$lambda$1969856002$1;
+            ]
+        }
+    }
+    
+    
     <init> {
         desc: ()V
         type: Regular
@@ -128,27 +144,27 @@ ComposableSingletons$FooKt$lambda$1969856002$1 {
             fieldDependencies: []
         }
     }
-    
-    
-    <clinit> {
-        desc: ()V
-        type: Regular
-        Method {
-            key: null
-            codeHash: 2164608135
-            methodDependencies: [
-                ComposableSingletons$FooKt$lambda$1969856002$1.<init> ()V
-            ]
-            fieldDependencies: [
-                ComposableSingletons$FooKt$lambda$1969856002$1.INSTANCE LComposableSingletons$FooKt$lambda$1969856002$1;
-            ]
-        }
-    }
 }
 
 ComposableSingletons$FooKt$lambda$904522804$1 {
     val INSTANCE: LComposableSingletons$FooKt$lambda$904522804$1;
 
+    <clinit> {
+        desc: ()V
+        type: Regular
+        Method {
+            key: null
+            codeHash: 2886943498
+            methodDependencies: [
+                ComposableSingletons$FooKt$lambda$904522804$1.<init> ()V
+            ]
+            fieldDependencies: [
+                ComposableSingletons$FooKt$lambda$904522804$1.INSTANCE LComposableSingletons$FooKt$lambda$904522804$1;
+            ]
+        }
+    }
+    
+    
     <init> {
         desc: ()V
         type: Regular
@@ -187,22 +203,6 @@ ComposableSingletons$FooKt$lambda$904522804$1 {
                 ComposableSingletons$FooKt$lambda$904522804$1.invoke (Landroidx/compose/foundation/layout/ColumnScope;Landroidx/compose/runtime/Composer;I)V
             ]
             fieldDependencies: []
-        }
-    }
-    
-    
-    <clinit> {
-        desc: ()V
-        type: Regular
-        Method {
-            key: null
-            codeHash: 2886943498
-            methodDependencies: [
-                ComposableSingletons$FooKt$lambda$904522804$1.<init> ()V
-            ]
-            fieldDependencies: [
-                ComposableSingletons$FooKt$lambda$904522804$1.INSTANCE LComposableSingletons$FooKt$lambda$904522804$1;
-            ]
         }
     }
 }

--- a/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - static field access/application-info.txt
+++ b/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - static field access/application-info.txt
@@ -19,12 +19,12 @@ fun Foo() {
 FooKt {
     val x: I
 
-    getX {
-        desc: ()I
+    <clinit> {
+        desc: ()V
         type: Regular
         Method {
             key: null
-            codeHash: 3555685996
+            codeHash: 2373262093
             methodDependencies: []
             fieldDependencies: [
                 FooKt.x I
@@ -77,12 +77,12 @@ FooKt {
     }
     
     
-    <clinit> {
-        desc: ()V
+    getX {
+        desc: ()I
         type: Regular
         Method {
             key: null
-            codeHash: 2373262093
+            codeHash: 3555685996
             methodDependencies: []
             fieldDependencies: [
                 FooKt.x I

--- a/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - whitespace do not affect code hashes/application-info-after.txt
+++ b/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - whitespace do not affect code hashes/application-info-after.txt
@@ -32,6 +32,41 @@ fun Bar() {
 */
 
 FooKt {
+    Bar {
+        desc: (Landroidx/compose/runtime/Composer;I)V
+        type: Composable
+        Method {
+            key: -2097341767
+            codeHash: 1143768317
+            methodDependencies: [
+                FooKt.Bar$lambda$0 (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+            ]
+            fieldDependencies: []
+    
+            RestartGroup {
+                key: -2097341767
+                codeHash: 3442577276
+                methodDependencies: []
+                fieldDependencies: []
+            }
+        }
+    }
+    
+    
+    Bar$lambda$0 {
+        desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+        type: Composable
+        Method {
+            key: null
+            codeHash: 2483986227
+            methodDependencies: [
+                FooKt.Bar (Landroidx/compose/runtime/Composer;I)V
+            ]
+            fieldDependencies: []
+        }
+    }
+    
+    
     Foo {
         desc: (Landroidx/compose/runtime/Composer;I)V
         type: Composable
@@ -55,27 +90,6 @@ FooKt {
     }
     
     
-    Bar {
-        desc: (Landroidx/compose/runtime/Composer;I)V
-        type: Composable
-        Method {
-            key: -2097341767
-            codeHash: 1143768317
-            methodDependencies: [
-                FooKt.Bar$lambda$0 (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
-            ]
-            fieldDependencies: []
-    
-            RestartGroup {
-                key: -2097341767
-                codeHash: 3442577276
-                methodDependencies: []
-                fieldDependencies: []
-            }
-        }
-    }
-    
-    
     Foo$lambda$0 {
         desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         type: Composable
@@ -84,20 +98,6 @@ FooKt {
             codeHash: 210770274
             methodDependencies: [
                 FooKt.Foo (Landroidx/compose/runtime/Composer;I)V
-            ]
-            fieldDependencies: []
-        }
-    }
-    
-    
-    Bar$lambda$0 {
-        desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
-        type: Composable
-        Method {
-            key: null
-            codeHash: 2483986227
-            methodDependencies: [
-                FooKt.Bar (Landroidx/compose/runtime/Composer;I)V
             ]
             fieldDependencies: []
         }

--- a/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - whitespace do not affect code hashes/application-info-before.txt
+++ b/hot-reload-analysis/src/test/resources/applicationInfo/org/jetbrains/compose/reload/analysis/tests/ApplicationInfoTest/test - whitespace do not affect code hashes/application-info-before.txt
@@ -24,6 +24,41 @@ fun Bar() {
 */
 
 FooKt {
+    Bar {
+        desc: (Landroidx/compose/runtime/Composer;I)V
+        type: Composable
+        Method {
+            key: -2097341767
+            codeHash: 1143768317
+            methodDependencies: [
+                FooKt.Bar$lambda$0 (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+            ]
+            fieldDependencies: []
+    
+            RestartGroup {
+                key: -2097341767
+                codeHash: 3442577276
+                methodDependencies: []
+                fieldDependencies: []
+            }
+        }
+    }
+    
+    
+    Bar$lambda$0 {
+        desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+        type: Composable
+        Method {
+            key: null
+            codeHash: 2483986227
+            methodDependencies: [
+                FooKt.Bar (Landroidx/compose/runtime/Composer;I)V
+            ]
+            fieldDependencies: []
+        }
+    }
+    
+    
     Foo {
         desc: (Landroidx/compose/runtime/Composer;I)V
         type: Composable
@@ -47,27 +82,6 @@ FooKt {
     }
     
     
-    Bar {
-        desc: (Landroidx/compose/runtime/Composer;I)V
-        type: Composable
-        Method {
-            key: -2097341767
-            codeHash: 1143768317
-            methodDependencies: [
-                FooKt.Bar$lambda$0 (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
-            ]
-            fieldDependencies: []
-    
-            RestartGroup {
-                key: -2097341767
-                codeHash: 3442577276
-                methodDependencies: []
-                fieldDependencies: []
-            }
-        }
-    }
-    
-    
     Foo$lambda$0 {
         desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         type: Composable
@@ -76,20 +90,6 @@ FooKt {
             codeHash: 210770274
             methodDependencies: [
                 FooKt.Foo (Landroidx/compose/runtime/Composer;I)V
-            ]
-            fieldDependencies: []
-        }
-    }
-    
-    
-    Bar$lambda$0 {
-        desc: (ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
-        type: Composable
-        Method {
-            key: null
-            codeHash: 2483986227
-            methodDependencies: [
-                FooKt.Bar (Landroidx/compose/runtime/Composer;I)V
             ]
             fieldDependencies: []
         }

--- a/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/logging.kt
+++ b/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/logging.kt
@@ -115,6 +115,13 @@ public inline fun Logger.debug(message: () -> String) {
 }
 
 @InternalHotReloadApi
+public inline fun Logger.info(message: () -> String) {
+    if (level <= Level.Info) {
+        log(Level.Info, message())
+    }
+}
+
+@InternalHotReloadApi
 public fun Logger.debug(message: String) {
     log(Level.Debug, message)
 }


### PR DESCRIPTION
### Main changes

* Custom string interning based on a weak hash map
* Collection optimisations
  * Use singleton objects whenever possible
  * Use hash maps/sets instead of their linked analogs
  * Replace dependency sets in `ScopeInfo` with lists: we don't need/use their set properties

### Side effects

* Explicitly sort scopes in `Iterable<ScopeInfo>.invalidationKey()` before computing hash. This way we are not relying on the original collections implementation details. Has negligible impact on the `resolveDirty` analysis: ~1ms slower. Collections in `invalidationKey` usually have only 1-2 elements
* Majority of the execution time (~70-80%) in `resolveDirty` is taken by `redefinition.dirtyMethodIds.entries.sortedBy { it.key.methodDescriptor }` and logging. I updated the implementation to only invoke sorting when the logging is enabled


### Results

Changes allow to save ~45-50% memory, especially on big projects. There are still many small memory optimisations that we can implement, but they will only provide small gains at the cost of a bigger impact on efficiency/public API behaviour

<img width="913" height="106" alt="Screenshot 2025-12-16 at 12 54 55" src="https://github.com/user-attachments/assets/502e741b-435f-41e6-879a-5c3f498f9464" />
<img width="919" height="109" alt="Screenshot 2025-12-16 at 12 55 01" src="https://github.com/user-attachments/assets/c13ac9ba-b151-4dfa-b2c3-622d35721642" />
