### PR TITLE
#470 fix eager task realization

### DIFF
--- a/hot-reload-gradle-core/src/main/kotlin/org/jetbrains/compose/reload/gradle/utils.kt
+++ b/hot-reload-gradle-core/src/main/kotlin/org/jetbrains/compose/reload/gradle/utils.kt
@@ -114,11 +114,11 @@ suspend fun <T> Project.forAllJvmCompilations(block: suspend (compilation: Kotli
     val futures = mutableListOf<Future<T>>()
 
     withKotlinPlugin {
-        kotlinJvmOrNull?.target?.compilations?.all { compilation ->
+        kotlinJvmOrNull?.target?.compilations?.configureEach { compilation ->
             futures += future { block(compilation) }
         }
-        kotlinMultiplatformOrNull?.targets?.withType(KotlinJvmTarget::class.java)?.all { target ->
-            target.compilations.all { compilation ->
+        kotlinMultiplatformOrNull?.targets?.withType(KotlinJvmTarget::class.java)?.configureEach { target ->
+            target.compilations.configureEach { compilation ->
                 futures += future { block(compilation) }
             }
         }
@@ -135,7 +135,7 @@ suspend fun <T> Project.forAllJvmTargets(block: suspend (target: KotlinTarget) -
             futures += future { block(target) }
         }
 
-        kotlinMultiplatformOrNull?.targets?.withType(KotlinJvmTarget::class.java)?.all { target ->
+        kotlinMultiplatformOrNull?.targets?.withType(KotlinJvmTarget::class.java)?.configureEach { target ->
             futures += future { block(target) }
         }
     }

--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/tasksBase.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/tasksBase.kt
@@ -31,8 +31,8 @@ interface ComposeHotReloadRunTask : ComposeHotTask
 interface ComposeHotReloadOtherTask : ComposeHotTask
 
 internal fun Project.configureComposeHotReloadTasks() {
-    tasks.withType<ComposeHotTask> {
-        group = when (this) {
+    tasks.withType<ComposeHotTask>().configureEach {
+        group = when (it) {
             is ComposeHotReloadOtherTask -> COMPOSE_HOT_RELOAD_OTHER_GROUP
             is ComposeHotReloadRunTask -> COMPOSE_HOT_RELOAD_RUN_GROUP
         }


### PR DESCRIPTION
- Replace `name in tasks.names` checks with `try-catch` around `tasks.register()`
- Removed unnecessary duplicate checks.
- Replace `.all {}` with `.configureEach {}`.
- Replace `tasks.withType<T> {}` with `tasks.withType<T>().configureEach {}`.