### PR TITLE
#470 fix eager task realization

### DIFF
--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/tasksBase.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/tasksBase.kt
@@ -31,8 +31,8 @@ interface ComposeHotReloadRunTask : ComposeHotTask
 interface ComposeHotReloadOtherTask : ComposeHotTask
 
 internal fun Project.configureComposeHotReloadTasks() {
-    tasks.withType<ComposeHotTask> {
-        group = when (this) {
+    tasks.withType<ComposeHotTask>().configureEach  {
+        it.group = when (it) {
             is ComposeHotReloadOtherTask -> COMPOSE_HOT_RELOAD_OTHER_GROUP
             is ComposeHotReloadRunTask -> COMPOSE_HOT_RELOAD_RUN_GROUP
         }


### PR DESCRIPTION
* Replace `tasks.withType<T> {}` with `tasks.withType<T>().configureEach {}`
* Add test that checks lazy realization

Based on the original PR #471 by @dovchinnikov. Moved to a separate PR for finalisation