### PR TITLE
CMP-9732: restart from tool window bug fix.

### DIFF
--- a/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotSnapshotTask.kt
+++ b/hot-reload-gradle-plugin/src/main/kotlin/org/jetbrains/compose/reload/gradle/hotSnapshotTask.kt
@@ -74,11 +74,11 @@ abstract class ComposeHotSnapshotTask : DefaultTask(), ComposeHotReloadOtherTask
     val pendingRequestFile: RegularFileProperty = project.objects.fileProperty()
 
     /**
-     * The output directory which contains changed/added .class files.
+     * The directory which contains changed/added .class files.
      * This directory should be part of the classpath of a running application to support loading
      * new classes from this directory.
      */
-    @get:OutputDirectory
+    @get:Internal
     val classesDirectory: DirectoryProperty = project.objects.directoryProperty()
 
 


### PR DESCRIPTION
Fixes: [CMP-9732](https://youtrack.jetbrains.com/issue/CMP-9732/Restart-button-in-Hot-Reload-Tool-Window-returns-the-app-to-the-state-before-the-changes)

After investigation, I noticed that `hot` directory is not exclusively owned by `hotSnapshot` task because `hotRun` task actually cleans it on the app start. 
So marking it `@OutputDirectory` seems to be not correct.

On the other hand, I have not noticed problems marking it as `@Internal` and it fixes the restart case.