### PR TITLE
[tests] Replace `AutoJbrProvisioning` annotation with `JbrProvisionin…

### DIFF
--- a/hot-reload-test/gradle-testFixtures/api/gradle-testFixtures.api
+++ b/hot-reload-test/gradle-testFixtures/api/gradle-testFixtures.api
@@ -21,10 +21,6 @@ public final class org/jetbrains/compose/reload/test/gradle/ApplicationLaunchMod
 	public final fun getDefault ()Lorg/jetbrains/compose/reload/test/gradle/ApplicationLaunchMode;
 }
 
-public abstract interface annotation class org/jetbrains/compose/reload/test/gradle/AutoJbrProvisioning : java/lang/annotation/Annotation {
-	public abstract fun isEnabled ()Z
-}
-
 public abstract interface annotation class org/jetbrains/compose/reload/test/gradle/BuildGradleKts : java/lang/annotation/Annotation {
 	public abstract fun path ()Ljava/lang/String;
 }
@@ -406,6 +402,11 @@ public final class org/jetbrains/compose/reload/test/gradle/HotReloadTestInvocat
 	public static final fun getTestedComposeVersion (Lorg/junit/jupiter/api/extension/ExtensionContext;)Lorg/jetbrains/compose/reload/test/gradle/TestedComposeVersion;
 	public static final fun getTestedGradleVersion (Lorg/junit/jupiter/api/extension/ExtensionContext;)Lorg/jetbrains/compose/reload/test/gradle/TestedGradleVersion;
 	public static final fun getTestedKotlinVersion (Lorg/junit/jupiter/api/extension/ExtensionContext;)Lorg/jetbrains/compose/reload/test/gradle/TestedKotlinVersion;
+}
+
+public abstract interface annotation class org/jetbrains/compose/reload/test/gradle/JbrProvisioning : java/lang/annotation/Annotation {
+	public abstract fun autoProvisioningEnabled ()Z
+	public abstract fun gradleProvisioningEnabled ()Z
 }
 
 public final class org/jetbrains/compose/reload/test/gradle/LaunchApplicationKt {

--- a/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/HotReloadTestFixtureExtension.kt
+++ b/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/HotReloadTestFixtureExtension.kt
@@ -22,7 +22,6 @@ import java.nio.file.Files
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.exists
 import kotlin.io.path.listDirectoryEntries
-import kotlin.io.path.name
 
 internal class HotReloadTestFixtureExtension(
     private val context: HotReloadTestInvocationContext
@@ -86,7 +85,9 @@ internal class HotReloadTestFixtureExtension(
         startOrchestrationTestLogging(orchestrationServer)
         val isHeadless = findAnnotation<Headless>()?.isHeadless ?: true
         val effectsEnabled = findAnnotation<ReloadEffects>()?.isEnabled ?: false
-        val autoJbrProvisioningEnabled = findAnnotation<AutoJbrProvisioning>()?.isEnabled ?: false
+        val jbrProvisioning = findAnnotation<JbrProvisioning>()
+        val gradleProvisioningEnabled = jbrProvisioning?.gradleProvisioningEnabled ?: true
+        val autoProvisioningEnabled = jbrProvisioning?.autoProvisioningEnabled ?: false
 
         val gradleRunner = GradleRunner(
             projectRoot = projectDir.path,
@@ -96,8 +97,8 @@ internal class HotReloadTestFixtureExtension(
                 "-P${HotReloadProperty.IsHeadless.key}=$isHeadless",
                 "-P${HotReloadProperty.LogLevel.key}=${Logger.Level.Debug.name}",
                 "-P${HotReloadProperty.ReloadEffectsEnabled.key}=$effectsEnabled",
-                "-P${HotReloadProperty.AutoJetBrainsRuntimeProvisioningEnabled.key}=$autoJbrProvisioningEnabled",
-                "-P${HotReloadProperty.GradleJetBrainsRuntimeProvisioningEnabled.key}=${!autoJbrProvisioningEnabled}",
+                "-P${HotReloadProperty.GradleJetBrainsRuntimeProvisioningEnabled.key}=$gradleProvisioningEnabled",
+                "-P${HotReloadProperty.AutoJetBrainsRuntimeProvisioningEnabled.key}=$autoProvisioningEnabled",
                 "--offline".takeIf { HotReloadEnvironment.gradleOfflineMode }
             ),
             stdoutChannel = Channel(),

--- a/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/annotations.kt
+++ b/hot-reload-test/gradle-testFixtures/src/main/kotlin/org/jetbrains/compose/reload/test/gradle/annotations.kt
@@ -42,7 +42,10 @@ public annotation class Headless(val isHeadless: Boolean = true)
 
 public annotation class ReloadEffects(val isEnabled: Boolean = true)
 
-public annotation class AutoJbrProvisioning(val isEnabled: Boolean = true)
+public annotation class JbrProvisioning(
+    val gradleProvisioningEnabled: Boolean = true,
+    val autoProvisioningEnabled: Boolean = false,
+)
 
 /**
  * Extends the build gradle kts file

--- a/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/gradle/ConfigurationCacheTest.kt
+++ b/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/gradle/ConfigurationCacheTest.kt
@@ -33,7 +33,7 @@ import org.jetbrains.compose.reload.orchestration.sendBlocking
 import org.jetbrains.compose.reload.orchestration.startOrchestrationListener
 import org.jetbrains.compose.reload.orchestration.toJvmArg
 import org.jetbrains.compose.reload.test.gradle.ApplicationLaunchMode
-import org.jetbrains.compose.reload.test.gradle.AutoJbrProvisioning
+import org.jetbrains.compose.reload.test.gradle.JbrProvisioning
 import org.jetbrains.compose.reload.test.gradle.ExtendGradleProperties
 import org.jetbrains.compose.reload.test.gradle.ExtendProjectSetup
 import org.jetbrains.compose.reload.test.gradle.GradleBuildEvent
@@ -53,8 +53,6 @@ import org.jetbrains.compose.reload.utils.TestOnlyDefaultComposeVersion
 import org.jetbrains.compose.reload.utils.TestOnlyDefaultKotlinVersion
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.fail
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
@@ -208,7 +206,7 @@ class ConfigurationCacheTest {
     }
 
     @HotReloadTest
-    @AutoJbrProvisioning
+    @JbrProvisioning(gradleProvisioningEnabled = false, autoProvisioningEnabled = true)
     fun `test - start app - auto jbr provisioning`(fixture: HotReloadTestFixture) = fixture.runTest {
         /* Start application: initialise JBR if necessary */
         fixture.runTransaction {
@@ -246,7 +244,7 @@ class ConfigurationCacheTest {
     }
 
     @HotReloadTest
-    @AutoJbrProvisioning
+    @JbrProvisioning(gradleProvisioningEnabled = false, autoProvisioningEnabled = true)
     fun `test - reload task - auto jbr provisioning`(fixture: HotReloadTestFixture) = fixture.runTest {
         /* Start application: initialise JBR if necessary */
         fixture.runTransaction {

--- a/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/gradle/JetBrainsRuntimeProvisioningTest.kt
+++ b/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/gradle/JetBrainsRuntimeProvisioningTest.kt
@@ -11,7 +11,7 @@ import org.jetbrains.compose.reload.core.HotReloadProperty
 import org.jetbrains.compose.reload.core.JavaHome
 import org.jetbrains.compose.reload.orchestration.OrchestrationClientRole
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
-import org.jetbrains.compose.reload.test.gradle.AutoJbrProvisioning
+import org.jetbrains.compose.reload.test.gradle.JbrProvisioning
 import org.jetbrains.compose.reload.test.gradle.BuildGradleKtsExtension
 import org.jetbrains.compose.reload.test.gradle.ExtendBuildGradleKts
 import org.jetbrains.compose.reload.test.gradle.ExtendSettingsGradleKts
@@ -76,7 +76,7 @@ class JetBrainsRuntimeProvisioningTest {
      * 3. Does not use foojay resolver plugin for JBR provisioning
      */
     @HotReloadTest
-    @AutoJbrProvisioning(isEnabled = true)
+    @JbrProvisioning(gradleProvisioningEnabled = false, autoProvisioningEnabled = true)
     @RequestToolchain("25", vendor = "AMAZON")
     @ExtendBuildGradleKts(TopLevelToolchain::class)
     @ExtendSettingsGradleKts(FoojayResolverPlugin::class)
@@ -84,7 +84,7 @@ class JetBrainsRuntimeProvisioningTest {
         fixture.`test - starts with expected jvm version`("25")
 
     @HotReloadTest
-    @AutoJbrProvisioning(isEnabled = true)
+    @JbrProvisioning(gradleProvisioningEnabled = false, autoProvisioningEnabled = true)
     @RequestToolchain("21", vendor = "AMAZON")
     @ExtendBuildGradleKts(TopLevelToolchain::class)
     @ExtendSettingsGradleKts(FoojayResolverPlugin::class)
@@ -112,13 +112,12 @@ class JetBrainsRuntimeProvisioningTest {
     }
 
     @HotReloadTest
+    @JbrProvisioning(gradleProvisioningEnabled = false, autoProvisioningEnabled = false)
     fun `test - use intellij fallback`(fixture: HotReloadTestFixture) = fixture.runTest {
         /* Provide garbage value, to trigger fallback */
         projectDir.gradleProperties.appendLines(
             listOf(
                 "${HotReloadProperty.JetBrainsRuntimeBinary.key}=xyz.garbage",
-                "${HotReloadProperty.GradleJetBrainsRuntimeProvisioningEnabled.key}=false",
-                "${HotReloadProperty.AutoJetBrainsRuntimeProvisioningEnabled.key}=false",
             )
         )
 


### PR DESCRIPTION
…g` for more fine-grained control over JBR provisioning options