### PR TITLE
[mcpserver] Add get_semantic_tree tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ layer and exposes the following tools:
 |------|-------------------------------------------------------------|
 | `status` | Checks whether a Compose application is currently connected |
 | `take_screenshot` | Captures a screenshot of the running application window     |
+| `get_semantic_tree` | Returns the Compose semantic/accessibility tree of the running application as JSON (component roles, names, descriptions, states, and bounds) |
 
 When the MCP server starts, it waits for the app to launch, detects shutdown, and
 reconnects automatically on restart.


### PR DESCRIPTION
- Adds a new `get_semantic_tree` tool to the MCP server, letting AI agents inspect the running Compose app's UI structurally (roles, text, bounds, state) instead of parsing screenshots.
- Introduces two new orchestration messages — `SemanticTreeRequest` and `SemanticTreeResult`

## Tests
- [x] `OrchestrationMessageTest` (classifier + availableSince golden data updated)
- [x] `SerialVersionUIDTest` (new messages registered)
- [x] `:tests:reloadFunctionalTest` — `SemanticTreeIntegrationTest` (windowed + headless)
- [x] Manual: asking ai agents about components