### PR TITLE
Recompiler: Disable unsafe incremental compilation for multiplatform by default

### DIFF
--- a/hot-reload-core/api/hot-reload-core.api
+++ b/hot-reload-core/api/hot-reload-core.api
@@ -239,6 +239,7 @@ public final class org/jetbrains/compose/reload/core/HotReloadEnvironment {
 	public final fun getDevToolsTransparencyEnabled ()Z
 	public final fun getGradleBuildContinuous ()Z
 	public final fun getGradleBuildOptimize ()Z
+	public final fun getGradleBuildOptimizeUnsafe ()Z
 	public final fun getGradleWarmupEnabled ()Z
 	public final fun getIsolatedProjectsEnabled ()Z
 	public final fun getLogLevel ()Lorg/jetbrains/compose/reload/core/Logger$Level;
@@ -259,6 +260,7 @@ public final class org/jetbrains/compose/reload/core/HotReloadProperty : java/la
 	public static final field DevToolsTransparencyEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field GradleBuildContinuous Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field GradleBuildOptimize Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field GradleBuildOptimizeUnsafe Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field GradleWarmupEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field IsHotReloadActive Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field IsolatedProjectsEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompiler.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompiler.kt
@@ -115,7 +115,7 @@ internal class GradleRecompiler(
                     "--build-cache".takeIf { HotReloadEnvironment.gradleBuildOptimize },
                     "--parallel".takeIf { HotReloadEnvironment.gradleBuildOptimize },
                     "-Pkotlin.internal.incremental.enableUnsafeOptimizationsForMultiplatform=true"
-                        .takeIf { HotReloadEnvironment.gradleBuildOptimize }
+                        .takeIf { HotReloadEnvironment.gradleBuildOptimizeUnsafe }
                 )
             )
         }

--- a/hot-reload-gradle-core/api/hot-reload-gradle-core.api
+++ b/hot-reload-gradle-core/api/hot-reload-gradle-core.api
@@ -22,6 +22,8 @@ public final class org/jetbrains/compose/reload/gradle/HotReloadGradleEnvironmen
 	public static final fun getComposeReloadGradleBuildContinuousProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
 	public static final fun getComposeReloadGradleBuildOptimize (Lorg/gradle/api/Project;)Z
 	public static final fun getComposeReloadGradleBuildOptimizeProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun getComposeReloadGradleBuildOptimizeUnsafe (Lorg/gradle/api/Project;)Z
+	public static final fun getComposeReloadGradleBuildOptimizeUnsafeProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
 	public static final fun getComposeReloadGradleWarmupEnabled (Lorg/gradle/api/Project;)Z
 	public static final fun getComposeReloadGradleWarmupEnabledProvider (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
 	public static final fun getComposeReloadIsolatedProjectsEnabled (Lorg/gradle/api/Project;)Z

--- a/properties.yaml
+++ b/properties.yaml
@@ -152,9 +152,21 @@ GradleBuildOptimize:
   target: [ application, devtools, build ]
   visibility: delicate
   documentation: |
-    - true: Compose Hot Reload will try to optimize your build during hot reload 
+    - true: Compose Hot Reload will try to optimize your build during hot reload
     (e.g. by enabling Gradle's configuration cache during 'recompilation')
     - false: No optimization will be performed.
+
+GradleBuildOptimizeUnsafe:
+  key: compose.reload.gradle.build.optimize.unsafe
+  type: boolean
+  default: "false"
+  target: [ application, devtools, build ]
+  visibility: delicate
+  documentation: |
+    - true: Compose Hot Reload will pass '-Pkotlin.internal.incremental.enableUnsafeOptimizationsForMultiplatform=true'
+    to Gradle during recompilation. This may improve incremental compilation performance but can cause unexpected
+    Kotlin compiler crashes (see https://youtrack.jetbrains.com/issue/CMP-10146).
+    - false: The unsafe incremental compilation optimization for multiplatform will not be enabled.
 
 AmperBuildRoot:
   key: amper.build.root


### PR DESCRIPTION
Move `-Pkotlin.internal.incremental.enableUnsafeOptimizationsForMultiplatform=true` from the `compose.reload.gradle.build.optimize` flag to a new dedicated `compose.reload.gradle.build.optimize.unsafe` property, defaulting to `false`. In other words, enable opt-in behavior as suggested  in the [PR](https://github.com/JetBrains/compose-hot-reload/pull/454) in case we find problems.

This optimization caused unexpected Kotlin compiler crashes that cannot be fixed in a timely fashion (see [CMP-10146](https://youtrack.jetbrains.com/issue/CMP-10146/CHR-hot-reload-fails-every-time-on-any-changes)).

