### PR TITLE
[mcpserver] Add UI actions tools: click, type_text, scroll, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ layer and exposes the following tools:
 | `status` | Checks whether a Compose application is currently connected |
 | `take_screenshot` | Captures a screenshot of the running application window     |
 | `get_semantic_tree` | Returns the Compose semantic/accessibility tree of the running application as JSON (component roles, names, descriptions, states, and bounds) |
+| `click` | Clicks the UI element with the given `nodeId`. The node must expose `onClick` in `get_semantic_tree` |
+| `long_click` | Long-presses the UI element with the given `nodeId`. The node must expose `onLongClick` |
+| `type_text` | Replaces the content of an editable text field (`nodeId`) with the given `text`. The node must expose `editableText` |
+| `scroll` | Scrolls a scrollable container (`nodeId`) by `deltaX` / `deltaY` logical pixels. The node must support the `ScrollBy` semantic action |
+| `scroll_to_index` | Scrolls a container (e.g. `LazyColumn` / `LazyRow`, `nodeId`) so the item at zero-based `index` becomes visible. The node must support the `ScrollToIndex` semantic action |
 
 When the MCP server starts, it waits for the app to launch, detects shutdown, and
 reconnects automatically on restart.

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -9,11 +9,14 @@ import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.Transport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.filterIsInstance
@@ -22,6 +25,14 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import org.jetbrains.compose.reload.DelicateHotReloadApi
 import org.jetbrains.compose.reload.core.HOT_RELOAD_VERSION
 import org.jetbrains.compose.reload.core.createLogger
@@ -29,10 +40,14 @@ import org.jetbrains.compose.reload.core.debug
 import org.jetbrains.compose.reload.core.info
 import org.jetbrains.compose.reload.core.warn
 import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotResult
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeResult
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIAction
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionResult
 import org.jetbrains.compose.reload.orchestration.asChannel
 import java.util.Base64
 import kotlin.time.Duration.Companion.seconds
@@ -83,6 +98,65 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
                 "Use the 'status' tool first to check if the application is connected."
         ) { _ ->
             handleGetSemanticTree(orchestration)
+        }
+
+        addTool(
+            name = "click",
+            description = "Click a UI element. The element must have 'onClick' in its " +
+                "'actions' list as reported by 'get_semantic_tree'.",
+            inputSchema = nodeIdToolSchema()
+        ) { request ->
+            handleUIAction(orchestration, request) { UIAction.Click }
+        }
+
+        addTool(
+            name = "long_click",
+            description = "Long-click (long press) a UI element. The element must have " +
+                "'onLongClick' in its 'actions' list as reported by 'get_semantic_tree'.",
+            inputSchema = nodeIdToolSchema()
+        ) { request ->
+            handleUIAction(orchestration, request) { UIAction.LongClick }
+        }
+
+        addTool(
+            name = "type_text",
+            description = "Replace the content of a text field with the given text. " +
+                "The element must expose 'editableText' as reported by 'get_semantic_tree'.",
+            inputSchema = typeTextToolSchema()
+        ) { request ->
+            handleUIAction(orchestration, request) { args ->
+                val text = (args?.get("text") as? JsonPrimitive)?.content
+                    ?: error("Missing required parameter 'text'")
+                UIAction.SetText(text)
+            }
+        }
+
+        addTool(
+            name = "scroll",
+            description = "Scroll a scrollable container by the given delta in logical pixels. " +
+                "Positive deltaX scrolls right; positive deltaY scrolls down. " +
+                "The element must support the ScrollBy semantic action.",
+            inputSchema = scrollToolSchema()
+        ) { request ->
+            handleUIAction(orchestration, request) { args ->
+                val deltaX = args?.get("deltaX")?.jsonPrimitive?.floatOrNull ?: 0f
+                val deltaY = args?.get("deltaY")?.jsonPrimitive?.floatOrNull ?: 0f
+                UIAction.ScrollBy(deltaX, deltaY)
+            }
+        }
+
+        addTool(
+            name = "scroll_to_index",
+            description = "Scroll a scrollable container (e.g. a LazyColumn / LazyRow) so that the item " +
+                "at the given index becomes visible. The element must support the ScrollToIndex " +
+                "semantic action.",
+            inputSchema = scrollToIndexToolSchema()
+        ) { request ->
+            handleUIAction(orchestration, request) { args ->
+                val index = args?.get("index")?.jsonPrimitive?.intOrNull
+                    ?: error("Missing required parameter 'index'")
+                UIAction.ScrollToIndex(index)
+            }
         }
     }
 
@@ -180,6 +254,129 @@ private suspend fun handleGetSemanticTree(orchestration: StateFlow<Orchestration
         logger.warn("get_semantic_tree: exception: ${e.message}")
         CallToolResult(
             content = listOf(TextContent("Semantic tree request failed: ${e.message}")),
+            isError = true
+        )
+    }
+}
+
+private fun nodeIdToolSchema(): ToolSchema = ToolSchema(
+    properties = buildJsonObject {
+        putJsonObject("nodeId") {
+            put("type", "integer")
+            put("description", "Semantic node id as reported by 'get_semantic_tree'.")
+        }
+    },
+    required = listOf("nodeId"),
+)
+
+private fun typeTextToolSchema(): ToolSchema = ToolSchema(
+    properties = buildJsonObject {
+        putJsonObject("nodeId") {
+            put("type", "integer")
+            put("description", "Semantic node id as reported by 'get_semantic_tree'.")
+        }
+        putJsonObject("text") {
+            put("type", "string")
+            put("description", "Text to set as the content of the editable field.")
+        }
+    },
+    required = listOf("nodeId", "text"),
+)
+
+private fun scrollToolSchema(): ToolSchema = ToolSchema(
+    properties = buildJsonObject {
+        putJsonObject("nodeId") {
+            put("type", "integer")
+            put("description", "Semantic node id of the scrollable container as reported by 'get_semantic_tree'.")
+        }
+        putJsonObject("deltaX") {
+            put("type", "number")
+            put("description", "Horizontal scroll delta in logical pixels (positive = right).")
+        }
+        putJsonObject("deltaY") {
+            put("type", "number")
+            put("description", "Vertical scroll delta in logical pixels (positive = down).")
+        }
+    },
+    required = listOf("nodeId"),
+)
+
+private fun scrollToIndexToolSchema(): ToolSchema = ToolSchema(
+    properties = buildJsonObject {
+        putJsonObject("nodeId") {
+            put("type", "integer")
+            put("description", "Semantic node id of the scrollable container as reported by 'get_semantic_tree'.")
+        }
+        putJsonObject("index") {
+            put("type", "integer")
+            put("description", "Zero-based index of the item to scroll to.")
+        }
+    },
+    required = listOf("nodeId", "index"),
+)
+
+private suspend fun handleUIAction(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    request: CallToolRequest,
+    actionFactory: (JsonObject?) -> UIAction,
+): CallToolResult {
+    val handle = orchestration.value
+        ?: return CallToolResult(
+            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
+            isError = true
+        ).also { logger.info { "${request.name}: no application connected" } }
+
+    val args = request.arguments
+    val nodeId = args?.get("nodeId")?.jsonPrimitive?.intOrNull
+        ?: return CallToolResult(
+            content = listOf(TextContent("Missing required parameter 'nodeId' (integer)")),
+            isError = true
+        )
+
+    val action = try {
+        actionFactory(args)
+    } catch (e: Exception) {
+        return CallToolResult(
+            content = listOf(TextContent(e.message ?: "Invalid arguments")),
+            isError = true
+        )
+    }
+
+    return try {
+        val uiActionRequest = UIActionRequest(nodeId = nodeId, action = action)
+        logger.info { "${request.name}: sending request '${uiActionRequest.messageId}' nodeId=$nodeId action=$action" }
+        val actionChannel: ReceiveChannel<OrchestrationMessage> = handle.asChannel()
+
+        handle.send(uiActionRequest)
+
+        val actionResult = withTimeoutOrNull(10.seconds) {
+            actionChannel.consumeAsFlow()
+                .filterIsInstance<UIActionResult>()
+                .first { it.uiActionRequestId == uiActionRequest.messageId }
+        }
+
+        if (actionResult == null) {
+            logger.warn("${request.name}: timed out waiting for response")
+            return CallToolResult(
+                content = listOf(TextContent("UI action timed out: no response from application")),
+                isError = true
+            )
+        }
+
+        if (!actionResult.isSuccess) {
+            logger.warn("${request.name}: failed: ${actionResult.errorMessage}")
+            return CallToolResult(
+                content = listOf(TextContent("UI action failed: ${actionResult.errorMessage ?: "unknown error"}")),
+                isError = true
+            )
+        }
+
+        logger.debug { "${request.name}: succeeded" }
+        CallToolResult(content = listOf(TextContent("""{"success": true}""")))
+    } catch (e: Exception) {
+        logger.warn("${request.name}: exception: ${e.message}")
+        CallToolResult(
+            content = listOf(TextContent("UI action failed: ${e.message}")),
             isError = true
         )
     }

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -26,6 +26,9 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.Screensho
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotResult
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeResult
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIAction
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionResult
 import org.jetbrains.compose.reload.orchestration.asFlow
 import org.jetbrains.compose.reload.orchestration.connectOrchestrationClient
 import org.jetbrains.compose.reload.orchestration.OrchestrationClientRole
@@ -165,6 +168,184 @@ class McpServerTest {
             assertNotEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertEquals(someJson, text)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - click returns error when disconnected`() = runTest(timeout = 10.seconds) {
+        val orchestration = MutableStateFlow<OrchestrationHandle?>(null)
+        val client = createMcpClient(orchestration)
+
+        val result = client.callTool("click", mapOf("nodeId" to 42))
+        assertEquals(true, result.isError)
+        val text = (result.content.first() as TextContent).text
+        assertTrue(text.contains("No application is currently connected"))
+    }
+
+    @Test
+    fun `test - click succeeds and forwards nodeId`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedNodeId: Int? = null
+            var receivedAction: UIAction? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<UIActionRequest>().first()
+                receivedNodeId = request.nodeId
+                receivedAction = request.action
+                server.send(UIActionResult(uiActionRequestId = request.messageId, isSuccess = true))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("click", mapOf("nodeId" to 7))
+            assertNotEquals(true, result.isError)
+            assertEquals(7, receivedNodeId)
+            assertEquals(UIAction.Click, receivedAction)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - click returns error when app reports failure`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            launch {
+                val request = server.asFlow().filterIsInstance<UIActionRequest>().first()
+                server.send(
+                    UIActionResult(
+                        uiActionRequestId = request.messageId,
+                        isSuccess = false,
+                        errorMessage = "Node 7 not found",
+                    )
+                )
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("click", mapOf("nodeId" to 7))
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Node 7 not found"))
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - long_click succeeds and dispatches LongClick action`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedAction: UIAction? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<UIActionRequest>().first()
+                receivedAction = request.action
+                server.send(UIActionResult(uiActionRequestId = request.messageId, isSuccess = true))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("long_click", mapOf("nodeId" to 3))
+            assertNotEquals(true, result.isError)
+            assertEquals(UIAction.LongClick, receivedAction)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - type_text forwards text to app`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedAction: UIAction? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<UIActionRequest>().first()
+                receivedAction = request.action
+                server.send(UIActionResult(uiActionRequestId = request.messageId, isSuccess = true))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool(
+                "type_text",
+                mapOf("nodeId" to 11, "text" to "hello world"),
+            )
+            assertNotEquals(true, result.isError)
+            assertEquals(UIAction.SetText("hello world"), receivedAction)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - scroll forwards deltas to app`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedAction: UIAction? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<UIActionRequest>().first()
+                receivedAction = request.action
+                server.send(UIActionResult(uiActionRequestId = request.messageId, isSuccess = true))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool(
+                "scroll",
+                mapOf("nodeId" to 5, "deltaX" to 10.0, "deltaY" to -20.5),
+            )
+            assertNotEquals(true, result.isError)
+            assertEquals(UIAction.ScrollBy(10f, -20.5f), receivedAction)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - scroll_to_index forwards index to app`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedAction: UIAction? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<UIActionRequest>().first()
+                receivedAction = request.action
+                server.send(UIActionResult(uiActionRequestId = request.messageId, isSuccess = true))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool(
+                "scroll_to_index",
+                mapOf("nodeId" to 5, "index" to 42),
+            )
+            assertNotEquals(true, result.isError)
+            assertEquals(UIAction.ScrollToIndex(42), receivedAction)
         } finally {
             server.close()
         }

--- a/hot-reload-orchestration/api/hot-reload-orchestration.api
+++ b/hot-reload-orchestration/api/hot-reload-orchestration.api
@@ -484,6 +484,70 @@ public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessa
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction : java/io/Serializable {
+}
+
+public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$Click : org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction {
+	public static final field INSTANCE Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$Click;
+}
+
+public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$LongClick : org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction {
+	public static final field INSTANCE Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$LongClick;
+}
+
+public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollBy : org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction {
+	public fun <init> (FF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun copy (FF)Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollBy;
+	public static synthetic fun copy$default (Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollBy;FFILjava/lang/Object;)Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollBy;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeltaX ()F
+	public final fun getDeltaY ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollToIndex : org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollToIndex;
+	public static synthetic fun copy$default (Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollToIndex;IILjava/lang/Object;)Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollToIndex;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$SetText : org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$SetText;
+	public static synthetic fun copy$default (Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$SetText;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$SetText;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIActionRequest : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
+	public fun <init> (ILorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction;
+	public final fun getNodeId ()I
+	public fun hashCode ()I
+}
+
+public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIActionResult : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
+	public fun <init> (Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessageId;ZLjava/lang/String;)V
+	public synthetic fun <init> (Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessageId;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorMessage ()Ljava/lang/String;
+	public final fun getUiActionRequestId ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessageId;
+	public fun hashCode ()I
+	public final fun isSuccess ()Z
+}
+
 public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIException : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationMessage.kt
+++ b/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationMessage.kt
@@ -633,6 +633,106 @@ internal constructor() : OrchestrationPackage(), Serializable {
         }
     }
 
+    /**
+     * A UI interaction to be invoked on a semantic node identified by [UIActionRequest.nodeId].
+     */
+    public sealed class UIAction : Serializable {
+        internal companion object {
+            @Suppress("unused")
+            internal const val serialVersionUID: Long = 0L
+        }
+
+        public object Click : UIAction() {
+            private fun readResolve(): Any = Click
+        }
+
+        public object LongClick : UIAction() {
+            private fun readResolve(): Any = LongClick
+        }
+
+        public data class SetText(public val text: String) : UIAction() {
+            internal companion object {
+                @Suppress("unused")
+                internal const val serialVersionUID: Long = 0L
+            }
+        }
+
+        public data class ScrollBy(public val deltaX: Float, public val deltaY: Float) : UIAction() {
+            internal companion object {
+                @Suppress("unused")
+                internal const val serialVersionUID: Long = 0L
+            }
+        }
+
+        public data class ScrollToIndex(public val index: Int) : UIAction() {
+            internal companion object {
+                @Suppress("unused")
+                internal const val serialVersionUID: Long = 0L
+            }
+        }
+    }
+
+    /**
+     * Requests the application to perform a [UIAction] on the semantic node with the given [nodeId].
+     * The node ID corresponds to the `id` field returned by [SemanticTreeRequest] / [SemanticTreeResult].
+     */
+    public class UIActionRequest(
+        public val nodeId: Int,
+        public val action: UIAction,
+    ) : OrchestrationMessage() {
+        internal companion object {
+            @Suppress("unused")
+            internal const val serialVersionUID: Long = 0L
+        }
+
+        override fun hashCode(): Int {
+            var hashCode = nodeId.hashCode()
+            hashCode = 31 * hashCode + action.hashCode()
+            return hashCode
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (other === this) return true
+            if (other !is UIActionRequest) return false
+            if (other.nodeId != nodeId) return false
+            if (other.action != action) return false
+            return true
+        }
+    }
+
+    /**
+     * Response to a [UIActionRequest], carrying success/failure information.
+     * @param uiActionRequestId the [OrchestrationMessageId] of the originating [UIActionRequest]
+     * @param isSuccess whether the action was dispatched successfully
+     * @param errorMessage an error description if [isSuccess] is false
+     */
+    public class UIActionResult(
+        public val uiActionRequestId: OrchestrationMessageId,
+        public val isSuccess: Boolean = true,
+        public val errorMessage: String? = null,
+    ) : OrchestrationMessage() {
+        internal companion object {
+            @Suppress("unused")
+            internal const val serialVersionUID: Long = 0L
+        }
+
+        override fun hashCode(): Int {
+            var hashCode = uiActionRequestId.hashCode()
+            hashCode = 31 * hashCode + isSuccess.hashCode()
+            hashCode = 31 * hashCode + (errorMessage?.hashCode() ?: 0)
+            return hashCode
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (other === this) return true
+            if (other !is UIActionResult) return false
+            if (other.uiActionRequestId != uiActionRequestId) return false
+            if (other.isSuccess != isSuccess) return false
+            if (other.errorMessage != errorMessage) return false
+            return true
+        }
+    }
+
 
     /* Base implementation */
     public var messageId: OrchestrationMessageId = OrchestrationMessageId.random()

--- a/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationProtocolVersion.kt
+++ b/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationProtocolVersion.kt
@@ -80,5 +80,7 @@ internal val Class<out OrchestrationMessage>.availableSinceVersion: Orchestratio
         OrchestrationMessage.ScreenshotResult::class.java -> OrchestrationVersion.v1_5
         OrchestrationMessage.SemanticTreeRequest::class.java -> OrchestrationVersion.v1_5
         OrchestrationMessage.SemanticTreeResult::class.java -> OrchestrationVersion.v1_5
+        OrchestrationMessage.UIActionRequest::class.java -> OrchestrationVersion.v1_5
+        OrchestrationMessage.UIActionResult::class.java -> OrchestrationVersion.v1_5
         else -> OrchestrationVersion.v1
     }

--- a/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/orchestrationMessageEncoders.kt
+++ b/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/orchestrationMessageEncoders.kt
@@ -232,6 +232,96 @@ internal class SemanticTreeResultEncoder : OrchestrationMessageEncoder<Orchestra
     }
 }
 
+internal class UIActionRequestEncoder : OrchestrationMessageEncoder<OrchestrationMessage.UIActionRequest> {
+    override val messageType: Type<OrchestrationMessage.UIActionRequest> = type()
+    override val messageClassifier = classifier("UIActionRequest")
+
+    override fun encode(message: OrchestrationMessage.UIActionRequest): ByteArray = encodeByteArray {
+        writeFields(
+            "nodeId" to encodeByteArray { writeInt(message.nodeId) },
+            "action" to encodeUIAction(message.action),
+        )
+    }
+
+    override fun decode(data: ByteArray): Try<OrchestrationMessage.UIActionRequest> = data.tryDecode {
+        val fields = readFields()
+        OrchestrationMessage.UIActionRequest(
+            nodeId = fields.requireField("nodeId").decode { readInt() },
+            action = fields.requireField("action").decode { readUIAction() },
+        )
+    }
+
+    private fun encodeUIAction(action: OrchestrationMessage.UIAction): ByteArray = encodeByteArray {
+        when (action) {
+            is OrchestrationMessage.UIAction.Click -> {
+                writeString("Click")
+                writeFields()
+            }
+            is OrchestrationMessage.UIAction.LongClick -> {
+                writeString("LongClick")
+                writeFields()
+            }
+            is OrchestrationMessage.UIAction.SetText -> {
+                writeString("SetText")
+                writeFields("text" to action.text.encodeToByteArray())
+            }
+            is OrchestrationMessage.UIAction.ScrollBy -> {
+                writeString("ScrollBy")
+                writeFields(
+                    "deltaX" to encodeByteArray(4) { writeFloat(action.deltaX) },
+                    "deltaY" to encodeByteArray(4) { writeFloat(action.deltaY) },
+                )
+            }
+            is OrchestrationMessage.UIAction.ScrollToIndex -> {
+                writeString("ScrollToIndex")
+                writeFields("index" to encodeByteArray(4) { writeInt(action.index) })
+            }
+        }
+    }
+
+    private fun java.io.DataInputStream.readUIAction(): OrchestrationMessage.UIAction {
+        val type = readString()
+        val fields = readFields()
+        return when (type) {
+            "Click" -> OrchestrationMessage.UIAction.Click
+            "LongClick" -> OrchestrationMessage.UIAction.LongClick
+            "SetText" -> OrchestrationMessage.UIAction.SetText(
+                text = fields.requireField("text").decodeToString()
+            )
+            "ScrollBy" -> OrchestrationMessage.UIAction.ScrollBy(
+                deltaX = fields.requireField("deltaX").decode { readFloat() },
+                deltaY = fields.requireField("deltaY").decode { readFloat() },
+            )
+            "ScrollToIndex" -> OrchestrationMessage.UIAction.ScrollToIndex(
+                index = fields.requireField("index").decode { readInt() }
+            )
+            else -> error("Unknown UIAction type: $type")
+        }
+    }
+}
+
+internal class UIActionResultEncoder : OrchestrationMessageEncoder<OrchestrationMessage.UIActionResult> {
+    override val messageType: Type<OrchestrationMessage.UIActionResult> = type()
+    override val messageClassifier = classifier("UIActionResult")
+
+    override fun encode(message: OrchestrationMessage.UIActionResult): ByteArray = encodeByteArray {
+        writeFields(
+            "uiActionRequestId" to message.uiActionRequestId.encodeToByteArray(),
+            "isSuccess" to message.isSuccess.encodeToByteArray(),
+            "errorMessage" to message.errorMessage?.encodeToByteArray(),
+        )
+    }
+
+    override fun decode(data: ByteArray): Try<OrchestrationMessage.UIActionResult> = data.tryDecode {
+        val fields = readFields()
+        OrchestrationMessage.UIActionResult(
+            uiActionRequestId = OrchestrationMessageId(fields.requireField("uiActionRequestId")),
+            isSuccess = fields["isSuccess"]?.decodeToBoolean() ?: true,
+            errorMessage = fields["errorMessage"]?.decodeToString(),
+        )
+    }
+}
+
 internal class PingEncoder : OrchestrationMessageEncoder<OrchestrationMessage.Ping> {
     override val messageType: Type<OrchestrationMessage.Ping> = type()
     override val messageClassifier = classifier("Ping")

--- a/hot-reload-orchestration/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationMessageEncoder
+++ b/hot-reload-orchestration/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationMessageEncoder
@@ -14,6 +14,8 @@ org.jetbrains.compose.reload.orchestration.ReloadClassesRequestEncoder
 org.jetbrains.compose.reload.orchestration.TakeScreenshotRequestEncoder
 org.jetbrains.compose.reload.orchestration.SemanticTreeRequestEncoder
 org.jetbrains.compose.reload.orchestration.SemanticTreeResultEncoder
+org.jetbrains.compose.reload.orchestration.UIActionRequestEncoder
+org.jetbrains.compose.reload.orchestration.UIActionResultEncoder
 org.jetbrains.compose.reload.orchestration.PingEncoder
 org.jetbrains.compose.reload.orchestration.CleanCompositionRequestEncoder
 org.jetbrains.compose.reload.orchestration.RetryFailedCompositionRequestEncoder

--- a/hot-reload-orchestration/src/test/resources/testData/message_availableSince.txt
+++ b/hot-reload-orchestration/src/test/resources/testData/message_availableSince.txt
@@ -32,3 +32,5 @@ org.jetbrains.compose.reload.orchestration.OrchestrationMessage$ScreenshotReques
 org.jetbrains.compose.reload.orchestration.OrchestrationMessage$ScreenshotResult = v1.5(6)
 org.jetbrains.compose.reload.orchestration.OrchestrationMessage$SemanticTreeRequest = v1.5(6)
 org.jetbrains.compose.reload.orchestration.OrchestrationMessage$SemanticTreeResult = v1.5(6)
+org.jetbrains.compose.reload.orchestration.OrchestrationMessage$UIActionRequest = v1.5(6)
+org.jetbrains.compose.reload.orchestration.OrchestrationMessage$UIActionResult = v1.5(6)

--- a/hot-reload-orchestration/src/test/resources/testData/message_classifier.txt
+++ b/hot-reload-orchestration/src/test/resources/testData/message_classifier.txt
@@ -30,6 +30,8 @@ root/SemanticTreeResult                    => o.j.c.r.o.OrchestrationMessage$Sem
 root/ShutdownRequest                       => o.j.c.r.o.OrchestrationMessage$ShutdownRequest
 root/TakeScreenshotRequest                 => o.j.c.r.o.OrchestrationMessage$TakeScreenshotRequest
 root/TestEvent                             => o.j.c.r.o.OrchestrationMessage$TestEvent
+root/UIActionRequest                       => o.j.c.r.o.OrchestrationMessage$UIActionRequest
+root/UIActionResult                        => o.j.c.r.o.OrchestrationMessage$UIActionResult
 root/UIException                           => o.j.c.r.o.OrchestrationMessage$UIException
 root/UIRendered                            => o.j.c.r.o.OrchestrationMessage$UIRendered
 

--- a/hot-reload-orchestration/src/test/resources/testData/serialVersionUIDs.txt
+++ b/hot-reload-orchestration/src/test/resources/testData/serialVersionUIDs.txt
@@ -39,6 +39,14 @@ org/jetbrains/compose/reload/orchestration/OrchestrationMessage$SemanticTreeResu
 org/jetbrains/compose/reload/orchestration/OrchestrationMessage$ShutdownRequest = 0
 org/jetbrains/compose/reload/orchestration/OrchestrationMessage$TakeScreenshotRequest = 0
 org/jetbrains/compose/reload/orchestration/OrchestrationMessage$TestEvent = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$Click = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$LongClick = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollBy = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$ScrollToIndex = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction$SetText = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIActionRequest = 0
+org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIActionResult = 0
 org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIException = 0
 org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIRendered = 0
 org/jetbrains/compose/reload/orchestration/OrchestrationMessageClassifier = 0

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
@@ -34,6 +34,7 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.CleanComp
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RetryFailedCompositionRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIException
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIRendered
 import org.jetbrains.compose.reload.orchestration.asFlow
@@ -82,6 +83,12 @@ public fun DevelopmentEntryPoint(
         LaunchedEffect(Unit) {
             orchestration.asFlow().filterIsInstance<SemanticTreeRequest>().collect { request ->
                 handleSemanticTreeRequest(request, window).sendAsync()
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            orchestration.asFlow().filterIsInstance<UIActionRequest>().collect { request ->
+                handleUIActionRequest(request, window).sendAsync()
             }
         }
     }

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/runHeadless.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/runHeadless.kt
@@ -273,6 +273,12 @@ public suspend fun runHeadlessApplication(
                     )
                 )
             }
+
+            if (message is OrchestrationMessage.UIActionRequest) {
+                scene.render(virtualTime)
+                val rootNode = scene.tryGetRootSemanticsNode()
+                orchestration.send(handleUIActionRequest(message, rootNode))
+            }
         }
 
     }

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/semanticTreeHandler.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/semanticTreeHandler.kt
@@ -41,7 +41,7 @@ private const val MAX_ACCESSIBILITY_TREE_SEARCH_DEPTH = 8
  * class that has a public `getSemanticsNode()` method.  Once any such node is
  * found we walk up via [SemanticsNode.parent] until we reach the root.
  */
-private fun findRootSemanticsNode(accessible: Accessible, depth: Int = 0): SemanticsNode? {
+internal fun findRootSemanticsNode(accessible: Accessible, depth: Int = 0): SemanticsNode? {
     if (depth > MAX_ACCESSIBILITY_TREE_SEARCH_DEPTH) return null
     val node = accessible.getSemanticsNodeOrNull()
     if (node != null) {

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/uiActionHandler.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/uiActionHandler.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024-2026 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.jvm
+
+import androidx.compose.ui.semantics.AccessibilityAction
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.text.AnnotatedString
+import org.jetbrains.compose.reload.core.createLogger
+import org.jetbrains.compose.reload.core.info
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIAction
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionResult
+import java.awt.Window
+
+private val logger = createLogger()
+
+internal fun handleUIActionRequest(request: UIActionRequest, window: Window): UIActionResult {
+    val rootNode = findRootSemanticsNode(window)
+    return handleUIActionRequest(request, rootNode)
+}
+
+internal fun handleUIActionRequest(request: UIActionRequest, rootNode: SemanticsNode?): UIActionResult {
+    logger.info("Handling UI action: '${request.messageId}' nodeId=${request.nodeId} action=${request.action}")
+    return try {
+        dispatchUIAction(request, rootNode)
+    } catch (e: Exception) {
+        logger.info("UI action failed: ${e.message}")
+        UIActionResult(
+            uiActionRequestId = request.messageId,
+            isSuccess = false,
+            errorMessage = "UI action failed: ${e.message}",
+        )
+    }
+}
+
+private fun dispatchUIAction(request: UIActionRequest, rootNode: SemanticsNode?): UIActionResult {
+    rootNode ?: return UIActionResult(
+        uiActionRequestId = request.messageId,
+        isSuccess = false,
+        errorMessage = "No semantic owners available",
+    )
+
+    val node = findSemanticsNodeById(rootNode, request.nodeId)
+        ?: return UIActionResult(
+            uiActionRequestId = request.messageId,
+            isSuccess = false,
+            errorMessage = "Node ${request.nodeId} not found",
+        )
+
+    return when (val action = request.action) {
+        is UIAction.Click -> invokeNoArgAction(
+            request, node, SemanticsActions.OnClick, "onClick"
+        )
+        is UIAction.LongClick -> invokeNoArgAction(
+            request, node, SemanticsActions.OnLongClick, "onLongClick"
+        )
+        is UIAction.SetText -> {
+            val setText = node.config.getOrNull(SemanticsActions.SetText)
+                ?: return missingAction(request, "SetText")
+            val lambda = setText.action
+                ?: return missingActionLambda(request, "SetText")
+            val handled = lambda.invoke(AnnotatedString(action.text))
+            toActionResult(request, handled, "SetText")
+        }
+        is UIAction.ScrollBy -> {
+            val scrollBy = node.config.getOrNull(SemanticsActions.ScrollBy)
+                ?: return missingAction(request, "ScrollBy")
+            val lambda = scrollBy.action
+                ?: return missingActionLambda(request, "ScrollBy")
+            val handled = lambda.invoke(action.deltaX, action.deltaY)
+            toActionResult(request, handled, "ScrollBy")
+        }
+        is UIAction.ScrollToIndex -> {
+            val scrollToIndex = node.config.getOrNull(SemanticsActions.ScrollToIndex)
+                ?: return missingAction(request, "ScrollToIndex")
+            val lambda = scrollToIndex.action
+                ?: return missingActionLambda(request, "ScrollToIndex")
+            val handled = lambda.invoke(action.index)
+            toActionResult(request, handled, "ScrollToIndex")
+        }
+    }
+}
+
+private fun invokeNoArgAction(
+    request: UIActionRequest,
+    node: SemanticsNode,
+    key: androidx.compose.ui.semantics.SemanticsPropertyKey<AccessibilityAction<() -> Boolean>>,
+    name: String,
+): UIActionResult {
+    val action = node.config.getOrNull(key) ?: return missingAction(request, name)
+    val lambda = action.action ?: return missingActionLambda(request, name)
+    val handled = lambda.invoke()
+    return toActionResult(request, handled, name)
+}
+
+private fun missingAction(request: UIActionRequest, name: String) = UIActionResult(
+    uiActionRequestId = request.messageId,
+    isSuccess = false,
+    errorMessage = "Node ${request.nodeId} does not support $name",
+)
+
+private fun missingActionLambda(request: UIActionRequest, name: String) = UIActionResult(
+    uiActionRequestId = request.messageId,
+    isSuccess = false,
+    errorMessage = "Node ${request.nodeId} has $name action without a handler",
+)
+
+private fun toActionResult(request: UIActionRequest, handled: Boolean, name: String) =
+    if (handled) UIActionResult(uiActionRequestId = request.messageId, isSuccess = true)
+    else UIActionResult(
+        uiActionRequestId = request.messageId,
+        isSuccess = false,
+        errorMessage = "$name action returned false on node ${request.nodeId}",
+    )
+
+private fun findSemanticsNodeById(root: SemanticsNode, id: Int): SemanticsNode? {
+    if (root.id == id) return root
+    for (child in root.children) {
+        findSemanticsNodeById(child, id)?.let { return it }
+    }
+    return null
+}

--- a/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/UIActionIntegrationTest.kt
+++ b/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/UIActionIntegrationTest.kt
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2024-2026 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.tests
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeResult
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIAction
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionResult
+import org.jetbrains.compose.reload.test.gradle.HotReloadTest
+import org.jetbrains.compose.reload.test.gradle.HotReloadTestFixture
+import org.jetbrains.compose.reload.test.gradle.MinComposeVersion
+import org.jetbrains.compose.reload.test.gradle.initialSourceCode
+import org.jetbrains.compose.reload.utils.QuickTest
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@MinComposeVersion("1.9.0")
+@QuickTest
+class UIActionIntegrationTest {
+
+    @HotReloadTest
+    fun `test - click action`(fixture: HotReloadTestFixture) = fixture.runTest {
+        fixture initialSourceCode """
+            import androidx.compose.material.Button
+            import androidx.compose.material.Text
+            import androidx.compose.runtime.*
+            import org.jetbrains.compose.reload.test.screenshotTestApplication
+
+            fun main() = screenshotTestApplication(width = 300, height = 200) {
+                var count by remember { mutableStateOf(0) }
+                Button(onClick = { count++ }) { Text("Count: ${'$'}count") }
+            }
+        """.trimIndent()
+
+        val initialTree = fixture.fetchSemanticTree()
+        val buttonId = findNodeIdByText(initialTree, "Count: 0")
+            ?: error("Could not locate button in initial tree:\n$initialTree")
+
+        val result = fixture.dispatchUIAction(UIActionRequest(nodeId = buttonId, action = UIAction.Click))
+        assertTrue(result.isSuccess, "Click failed: ${result.errorMessage}")
+
+        val updatedTree = fixture.fetchSemanticTree()
+        assertNotNull(
+            findNodeIdByText(updatedTree, "Count: 1"),
+            "Expected counter to increment after click. Tree:\n$updatedTree"
+        )
+    }
+
+    @HotReloadTest
+    fun `test - long_click action`(fixture: HotReloadTestFixture) = fixture.runTest {
+        fixture initialSourceCode """
+            import androidx.compose.foundation.combinedClickable
+            import androidx.compose.foundation.interaction.MutableInteractionSource
+            import androidx.compose.foundation.layout.Box
+            import androidx.compose.material.Text
+            import androidx.compose.runtime.*
+            import androidx.compose.ui.Modifier
+            import org.jetbrains.compose.reload.test.screenshotTestApplication
+
+            @OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+            fun main() = screenshotTestApplication(width = 300, height = 200) {
+                var label by remember { mutableStateOf("initial") }
+                val interactionSource = remember { MutableInteractionSource() }
+                Box(
+                    Modifier.combinedClickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = {},
+                        onLongClick = { label = "long-clicked" },
+                    )
+                ) { Text(label) }
+            }
+        """.trimIndent()
+
+        val initialTree = fixture.fetchSemanticTree()
+        val targetId = findNodeIdWithAction(initialTree, "onLongClick")
+            ?: error("Could not find a node with onLongClick action in tree:\n$initialTree")
+
+        val result = fixture.dispatchUIAction(UIActionRequest(nodeId = targetId, action = UIAction.LongClick))
+        assertTrue(result.isSuccess, "LongClick failed: ${result.errorMessage}")
+
+        val updatedTree = fixture.fetchSemanticTree()
+        assertNotNull(
+            findNodeIdByText(updatedTree, "long-clicked"),
+            "Expected label to change after long click. Tree:\n$updatedTree"
+        )
+    }
+
+    @HotReloadTest
+    fun `test - type_text action`(fixture: HotReloadTestFixture) = fixture.runTest {
+        fixture initialSourceCode """
+            import androidx.compose.foundation.text.BasicTextField
+            import androidx.compose.material.LocalTextStyle
+            import androidx.compose.runtime.*
+            import org.jetbrains.compose.reload.test.screenshotTestApplication
+
+            fun main() = screenshotTestApplication(width = 300, height = 200) {
+                var value by remember { mutableStateOf("initial") }
+                BasicTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    textStyle = LocalTextStyle.current,
+                )
+            }
+        """.trimIndent()
+
+        val initialTree = fixture.fetchSemanticTree()
+        val fieldId = findEditableNodeId(initialTree)
+            ?: error("Could not locate editable text field in tree:\n$initialTree")
+
+        val result = fixture.dispatchUIAction(
+            UIActionRequest(nodeId = fieldId, action = UIAction.SetText("updated"))
+        )
+        assertTrue(result.isSuccess, "SetText failed: ${result.errorMessage}")
+
+        val updatedTree = fixture.fetchSemanticTree()
+        val updatedField = findNodeByPredicate(updatedTree) { node ->
+            (node["editableText"] as? JsonPrimitive)?.contentOrNull == "updated"
+        }
+        assertNotNull(updatedField, "Expected editable text to be 'updated'. Tree:\n$updatedTree")
+    }
+
+    @HotReloadTest
+    fun `test - scroll action`(fixture: HotReloadTestFixture) = fixture.runTest {
+        fixture initialSourceCode """
+            import androidx.compose.foundation.lazy.LazyColumn
+            import androidx.compose.foundation.lazy.items
+            import androidx.compose.material.Text
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.platform.testTag
+            import org.jetbrains.compose.reload.test.screenshotTestApplication
+
+            fun main() = screenshotTestApplication(width = 300, height = 200) {
+                LazyColumn(modifier = Modifier.testTag("scroller")) {
+                    items((1..50).toList()) { Text("Item ${'$'}it") }
+                }
+            }
+        """.trimIndent()
+
+        val initialTree = fixture.fetchSemanticTree()
+        val scrollableId = findNodeIdByTestTag(initialTree, "scroller")
+            ?: error("Could not find scrollable container in tree:\n$initialTree")
+        assertNotNull(
+            findNodeIdByText(initialTree, "Item 1"),
+            "Expected 'Item 1' to be visible before scroll. Tree:\n$initialTree"
+        )
+        assertNull(
+            findNodeIdByText(initialTree, "Item 45"),
+            "Expected 'Item 45' to NOT be visible before scroll. Tree:\n$initialTree"
+        )
+
+        val result = fixture.dispatchUIAction(
+            UIActionRequest(nodeId = scrollableId, action = UIAction.ScrollBy(deltaX = 0f, deltaY = 1000f))
+        )
+        assertTrue(result.isSuccess, "ScrollBy failed: ${result.errorMessage}")
+
+        val updatedTree = fixture.fetchSemanticTree()
+        assertNull(
+            findNodeIdByText(updatedTree, "Item 1"),
+            "Expected 'Item 1' to be scrolled out of view. Tree:\n$updatedTree"
+        )
+        assertNotNull(
+            findNodeIdByText(updatedTree, "Item 45"),
+            "Expected a later item (e.g. 'Item 45') to be visible after scroll. Tree:\n$updatedTree"
+        )
+    }
+
+    @HotReloadTest
+    fun `test - scroll_to_index action`(fixture: HotReloadTestFixture) = fixture.runTest {
+        fixture initialSourceCode """
+            import androidx.compose.foundation.lazy.LazyColumn
+            import androidx.compose.foundation.lazy.items
+            import androidx.compose.material.Text
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.platform.testTag
+            import org.jetbrains.compose.reload.test.screenshotTestApplication
+
+            fun main() = screenshotTestApplication(width = 300, height = 200) {
+                LazyColumn(modifier = Modifier.testTag("scroller")) {
+                    items((1..50).toList()) { Text("Item ${'$'}it") }
+                }
+            }
+        """.trimIndent()
+
+        val initialTree = fixture.fetchSemanticTree()
+        val scrollableId = findNodeIdByTestTag(initialTree, "scroller")
+            ?: error("Could not find scrollable container in tree:\n$initialTree")
+        assertNotNull(
+            findNodeIdByText(initialTree, "Item 1"),
+            "Expected 'Item 1' to be visible before scroll. Tree:\n$initialTree"
+        )
+        assertNull(
+            findNodeIdByText(initialTree, "Item 45"),
+            "Expected 'Item 45' to NOT be visible before scroll. Tree:\n$initialTree"
+        )
+
+        val result = fixture.dispatchUIAction(
+            UIActionRequest(nodeId = scrollableId, action = UIAction.ScrollToIndex(44))
+        )
+        assertTrue(result.isSuccess, "ScrollToIndex failed: ${result.errorMessage}")
+
+        val updatedTree = fixture.fetchSemanticTree()
+        assertNotNull(
+            findNodeIdByText(updatedTree, "Item 45"),
+            "Expected 'Item 45' to be visible after scrollToIndex(44). Tree:\n$updatedTree"
+        )
+        assertNull(
+            findNodeIdByText(updatedTree, "Item 1"),
+            "Expected 'Item 1' to be out of view after scrollToIndex(44). Tree:\n$updatedTree"
+        )
+    }
+
+    @HotReloadTest
+    fun `test - action on non-existent node returns error`(fixture: HotReloadTestFixture) = fixture.runTest {
+        fixture initialSourceCode """
+            import androidx.compose.material.Text
+            import org.jetbrains.compose.reload.test.screenshotTestApplication
+
+            fun main() = screenshotTestApplication(width = 300, height = 200) {
+                Text("Hello")
+            }
+        """.trimIndent()
+
+        // Wait for the app to be ready (semantic tree available)
+        fixture.fetchSemanticTree()
+
+        val result = fixture.dispatchUIAction(
+            UIActionRequest(nodeId = 99_999, action = UIAction.Click)
+        )
+        assertFalse(result.isSuccess, "Action on non-existent node should fail")
+        assertNotNull(result.errorMessage, "Error message expected")
+        assertTrue(
+            result.errorMessage!!.contains("not found", ignoreCase = true),
+            "Error message should mention 'not found' but was: ${result.errorMessage}"
+        )
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+private suspend fun HotReloadTestFixture.fetchSemanticTree(): String {
+    val request = SemanticTreeRequest()
+    return sendMessage(request) {
+        skipToMessage<SemanticTreeResult> { it.semanticTreeRequestId == request.messageId }
+    }.tree
+}
+
+private suspend fun HotReloadTestFixture.dispatchUIAction(request: UIActionRequest): UIActionResult =
+    sendMessage(request) {
+        skipToMessage<UIActionResult> { it.uiActionRequestId == request.messageId }
+    }
+
+private val jsonParser = Json { ignoreUnknownKeys = true; isLenient = true }
+
+private fun parseTree(tree: String): JsonObject = jsonParser.parseToJsonElement(tree).jsonObject
+
+private fun findNodeByPredicate(tree: String, predicate: (JsonObject) -> Boolean): JsonObject? =
+    findNodeByPredicate(parseTree(tree), predicate)
+
+private fun findNodeByPredicate(node: JsonObject, predicate: (JsonObject) -> Boolean): JsonObject? {
+    if (predicate(node)) return node
+    val children = node["children"] ?: return null
+    for (child in children.jsonArray) {
+        findNodeByPredicate(child.jsonObject, predicate)?.let { return it }
+    }
+    return null
+}
+
+private fun findNodeIdByText(tree: String, text: String): Int? =
+    findNodeByPredicate(tree) { node ->
+        (node["text"] as? JsonPrimitive)?.contentOrNull == text
+    }?.get("id")?.jsonPrimitive?.intOrNull
+
+private fun findNodeIdByTestTag(tree: String, tag: String): Int? =
+    findNodeByPredicate(tree) { node ->
+        (node["testTag"] as? JsonPrimitive)?.contentOrNull == tag
+    }?.get("id")?.jsonPrimitive?.intOrNull
+
+private fun findNodeIdWithAction(tree: String, action: String): Int? =
+    findNodeByPredicate(tree) { node ->
+        val actions = node["actions"]?.jsonArray ?: return@findNodeByPredicate false
+        actions.any { (it as? JsonPrimitive)?.contentOrNull == action }
+    }?.get("id")?.jsonPrimitive?.intOrNull
+
+private fun findEditableNodeId(tree: String): Int? =
+    findNodeByPredicate(tree) { node -> node.containsKey("editableText") }
+        ?.get("id")?.jsonPrimitive?.intOrNull


### PR DESCRIPTION
## Summary

Adds UI-action tools to the Compose Hot Reload MCP server so AI agents can drive a running Compose application, not just observe it. Built on top of the existing `get_semantic_tree` tool — agents read the tree to discover node ids and supported actions, then dispatch one of:

| Tool | Semantic action | Arguments |
|------|-----------------|-----------|
| `click` | `OnClick` | `nodeId` |
| `long_click` | `OnLongClick` | `nodeId` |
| `type_text` | `SetText` | `nodeId`, `text` |
| `scroll` | `ScrollBy` | `nodeId`, `deltaX`, `deltaY` |
| `scroll_to_index` | `ScrollToIndex` | `nodeId`, `index` |

Each tool returns only after the application has executed the action and acknowledged it (`UIActionResult`), so callers can chain a follow-up `get_semantic_tree` / `take_screenshot` to observe the effect.

## Implementation notes

- New orchestration messages `UIActionRequest` / `UIActionResult` and a `UIAction` sealed hierarchy (`Click`, `LongClick`, `SetText`, `ScrollBy`, `ScrollToIndex`), with encoders, golden serialization data, and protocol-version bump.
- `uiActionHandler.kt` in `hot-reload-runtime-jvm` resolves the target `SemanticsNode` by id and invokes the corresponding `SemanticsActions.*` lambda. Failure modes (missing node, action not supported by node, action lambda absent, lambda returns `false`) all map to descriptive `UIActionResult` errors.
- Dispatch is wired from both the windowed `DevelopmentEntryPoint` path and the headless `runHeadless.kt` path used by screenshot tests, so the tools are exercisable from functional tests without a real AWT window.

## Test plan

- [x] `UIActionIntegrationTest` — 6 cases: `click`, `long_click`, `type_text`, `scroll` (with pre/post assertions that `LazyColumn` actually scrolled), `scroll_to_index`, missing-node error
- [x] `McpServerTest` — per-tool tests asserting the correct `UIAction` subtype reaches the app
- [x] `:hot-reload-orchestration:check` — encoder roundtrip + serialVersionUID / protocol-classifier golden data
- [x] Manual smoke: configure agent via `.mcp.json` against KotlinConf app and navigate within it

## Documentation

Updated `README.md` MCP tool table with the five new tools.