### PR TITLE
Improve MCP server code readability

### DIFF
--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -62,6 +62,30 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
     startMcpServer(orchestration, transport)
 }
 
+/** A single input property in a tool's JSON schema. */
+private data class Property(val name: String, val type: String, val description: String)
+
+private val NodeId = Property("nodeId", "integer",
+    description = "Semantic node id as reported by 'get_semantic_tree'.")
+private val ScrollContainerNodeId = Property("nodeId", "integer",
+    description = "Semantic node id of the scrollable container as reported by 'get_semantic_tree'.")
+
+/** Builds a [ToolSchema] from [properties]; by default all of them are required. */
+private fun toolSchema(
+    vararg properties: Property,
+    required: List<String> = properties.map { it.name },
+): ToolSchema = ToolSchema(
+    properties = buildJsonObject {
+        properties.forEach { p ->
+            putJsonObject(p.name) {
+                put("type", p.type)
+                put("description", p.description)
+            }
+        }
+    },
+    required = required,
+)
+
 @OptIn(DelicateHotReloadApi::class)
 internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle?>, transport: Transport) {
     val server = Server(
@@ -104,7 +128,7 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             name = "click",
             description = "Click a UI element. The element must have 'onClick' in its " +
                 "'actions' list as reported by 'get_semantic_tree'.",
-            inputSchema = nodeIdToolSchema()
+            inputSchema = toolSchema(NodeId)
         ) { request ->
             handleUIAction(orchestration, request) { UIAction.Click }
         }
@@ -113,7 +137,7 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             name = "long_click",
             description = "Long-click (long press) a UI element. The element must have " +
                 "'onLongClick' in its 'actions' list as reported by 'get_semantic_tree'.",
-            inputSchema = nodeIdToolSchema()
+            inputSchema = toolSchema(NodeId)
         ) { request ->
             handleUIAction(orchestration, request) { UIAction.LongClick }
         }
@@ -122,7 +146,11 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             name = "type_text",
             description = "Replace the content of a text field with the given text. " +
                 "The element must expose 'editableText' as reported by 'get_semantic_tree'.",
-            inputSchema = typeTextToolSchema()
+            inputSchema = toolSchema(
+                NodeId,
+                Property("text", "string",
+                    description = "Text to set as the content of the editable field."),
+            )
         ) { request ->
             handleUIAction(orchestration, request) { args ->
                 val text = (args?.get("text") as? JsonPrimitive)?.content
@@ -136,7 +164,14 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             description = "Scroll a scrollable container by the given delta in logical pixels. " +
                 "Positive deltaX scrolls right; positive deltaY scrolls down. " +
                 "The element must support the ScrollBy semantic action.",
-            inputSchema = scrollToolSchema()
+            inputSchema = toolSchema(
+                ScrollContainerNodeId,
+                Property("deltaX", "number",
+                    description = "Horizontal scroll delta in logical pixels (positive = right)."),
+                Property("deltaY", "number",
+                    description = "Vertical scroll delta in logical pixels (positive = down)."),
+                required = listOf("nodeId"),
+            )
         ) { request ->
             handleUIAction(orchestration, request) { args ->
                 val deltaX = args?.get("deltaX")?.jsonPrimitive?.floatOrNull ?: 0f
@@ -150,7 +185,11 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             description = "Scroll a scrollable container (e.g. a LazyColumn / LazyRow) so that the item " +
                 "at the given index becomes visible. The element must support the ScrollToIndex " +
                 "semantic action.",
-            inputSchema = scrollToIndexToolSchema()
+            inputSchema = toolSchema(
+                ScrollContainerNodeId,
+                Property("index", "integer",
+                    description = "Zero-based index of the item to scroll to."),
+            )
         ) { request ->
             handleUIAction(orchestration, request) { args ->
                 val index = args?.get("index")?.jsonPrimitive?.intOrNull
@@ -247,62 +286,6 @@ private suspend fun handleGetSemanticTree(orchestration: StateFlow<Orchestration
         )
     }
 }
-
-private fun nodeIdToolSchema(): ToolSchema = ToolSchema(
-    properties = buildJsonObject {
-        putJsonObject("nodeId") {
-            put("type", "integer")
-            put("description", "Semantic node id as reported by 'get_semantic_tree'.")
-        }
-    },
-    required = listOf("nodeId"),
-)
-
-private fun typeTextToolSchema(): ToolSchema = ToolSchema(
-    properties = buildJsonObject {
-        putJsonObject("nodeId") {
-            put("type", "integer")
-            put("description", "Semantic node id as reported by 'get_semantic_tree'.")
-        }
-        putJsonObject("text") {
-            put("type", "string")
-            put("description", "Text to set as the content of the editable field.")
-        }
-    },
-    required = listOf("nodeId", "text"),
-)
-
-private fun scrollToolSchema(): ToolSchema = ToolSchema(
-    properties = buildJsonObject {
-        putJsonObject("nodeId") {
-            put("type", "integer")
-            put("description", "Semantic node id of the scrollable container as reported by 'get_semantic_tree'.")
-        }
-        putJsonObject("deltaX") {
-            put("type", "number")
-            put("description", "Horizontal scroll delta in logical pixels (positive = right).")
-        }
-        putJsonObject("deltaY") {
-            put("type", "number")
-            put("description", "Vertical scroll delta in logical pixels (positive = down).")
-        }
-    },
-    required = listOf("nodeId"),
-)
-
-private fun scrollToIndexToolSchema(): ToolSchema = ToolSchema(
-    properties = buildJsonObject {
-        putJsonObject("nodeId") {
-            put("type", "integer")
-            put("description", "Semantic node id of the scrollable container as reported by 'get_semantic_tree'.")
-        }
-        putJsonObject("index") {
-            put("type", "integer")
-            put("description", "Zero-based index of the item to scroll to.")
-        }
-    },
-    required = listOf("nodeId", "index"),
-)
 
 private suspend fun handleUIAction(
     orchestration: StateFlow<OrchestrationHandle?>,

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -16,7 +16,6 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
-import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.filterIsInstance
@@ -50,6 +49,7 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionR
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionResult
 import org.jetbrains.compose.reload.orchestration.asChannel
 import java.util.Base64
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 private val logger = createLogger()
@@ -181,15 +181,9 @@ private suspend fun handleTakeScreenshot(orchestration: StateFlow<OrchestrationH
     return try {
         val request = ScreenshotRequest()
         logger.info { "take_screenshot: sending request '${request.messageId}'" }
-        // asChannel() registers the listener eagerly before we send the request,
-        // avoiding the race condition where the result arrives before
-        // the cold asFlow() starts collecting. consumeAsFlow() auto-closes the channel.
-        val screenshot = handle.asChannel().consumeAsFlow()
-            .filterIsInstance<ScreenshotResult>()
-            .let { flow ->
-                handle.send(request)
-                withTimeoutOrNull(10.seconds) { flow.first { it.screenshotRequestId == request.messageId } }
-            }
+        val screenshot = handle.requestResponse<ScreenshotResult>(request) {
+            it.screenshotRequestId == request.messageId
+        }
 
         if (screenshot == null) {
             logger.warn("take_screenshot: timed out waiting for response")
@@ -231,14 +225,9 @@ private suspend fun handleGetSemanticTree(orchestration: StateFlow<Orchestration
     return try {
         val request = SemanticTreeRequest()
         logger.info { "get_semantic_tree: sending request '${request.messageId}'" }
-        val semanticTree = handle.asChannel().consumeAsFlow()
-            .filterIsInstance<SemanticTreeResult>()
-            .let { flow ->
-                handle.send(request)
-                withTimeoutOrNull(10.seconds) {
-                    flow.first { it.semanticTreeRequestId == request.messageId }
-                }
-            }
+        val semanticTree = handle.requestResponse<SemanticTreeResult>(request) {
+            it.semanticTreeRequestId == request.messageId
+        }
 
         if (semanticTree == null) {
             logger.warn("get_semantic_tree: timed out waiting for response")
@@ -345,14 +334,8 @@ private suspend fun handleUIAction(
     return try {
         val uiActionRequest = UIActionRequest(nodeId = nodeId, action = action)
         logger.info { "${request.name}: sending request '${uiActionRequest.messageId}' nodeId=$nodeId action=$action" }
-        val actionChannel: ReceiveChannel<OrchestrationMessage> = handle.asChannel()
-
-        handle.send(uiActionRequest)
-
-        val actionResult = withTimeoutOrNull(10.seconds) {
-            actionChannel.consumeAsFlow()
-                .filterIsInstance<UIActionResult>()
-                .first { it.uiActionRequestId == uiActionRequest.messageId }
+        val actionResult = handle.requestResponse<UIActionResult>(uiActionRequest) {
+            it.uiActionRequestId == uiActionRequest.messageId
         }
 
         if (actionResult == null) {
@@ -380,4 +363,26 @@ private suspend fun handleUIAction(
             isError = true
         )
     }
+}
+
+/**
+ * Sends [request] over orchestration and awaits the matching response of type [R],
+ * or returns null if no response arrives within [timeout].
+ *
+ * The response channel is opened *before* [request] is sent, eliminating the race
+ * where the result could otherwise arrive before a cold flow starts collecting.
+ * [consumeAsFlow] auto-closes the channel once the first match is found.
+ */
+private suspend inline fun <reified R : OrchestrationMessage> OrchestrationHandle.requestResponse(
+    request: OrchestrationMessage,
+    timeout: Duration = 10.seconds,
+    crossinline isResponse: (R) -> Boolean,
+): R? {
+    val channel = asChannel()
+    return channel.consumeAsFlow()
+        .filterIsInstance<R>()
+        .let { flow ->
+            send(request)
+            withTimeoutOrNull(timeout) { flow.first { isResponse(it) } }
+        }
 }


### PR DESCRIPTION
In respect to [the review message](https://github.com/JetBrains/compose-hot-reload/pull/522#discussion_r3259642024).

- removed request/response duplication across the tool handlers
- added a simple tool schema DSL and use it in addTool descriptors

