### PR TITLE
[mcpserver] Add multi-window support

### DIFF
--- a/hot-reload-devtools-api/api/hot-reload-devtools-api.api
+++ b/hot-reload-devtools-api/api/hot-reload-devtools-api.api
@@ -202,8 +202,11 @@ public final class org/jetbrains/compose/devtools/api/WindowsState$Key : org/jet
 public final class org/jetbrains/compose/devtools/api/WindowsState$WindowState {
 	public static final field $stable I
 	public fun <init> (IIIIZ)V
+	public fun <init> (IIIIZLjava/lang/String;)V
+	public synthetic fun <init> (IIIIZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHeight ()I
+	public final fun getTitle ()Ljava/lang/String;
 	public final fun getWidth ()I
 	public final fun getX ()I
 	public final fun getY ()I

--- a/hot-reload-devtools-api/src/main/kotlin/org/jetbrains/compose/devtools/api/WindowsState.kt
+++ b/hot-reload-devtools-api/src/main/kotlin/org/jetbrains/compose/devtools/api/WindowsState.kt
@@ -40,12 +40,13 @@ public class WindowsState(
         return "WindowsState($windows)"
     }
 
-    public class WindowState(
+    public class WindowState @JvmOverloads constructor(
         public val x: Int,
         public val y: Int,
         public val width: Int,
         public val height: Int,
-        public val isAlwaysOnTop: Boolean
+        public val isAlwaysOnTop: Boolean,
+        public val title: String? = null,
     ) {
         private val hashCode: Int = run {
             var result = x.hashCode()
@@ -53,6 +54,7 @@ public class WindowsState(
             result = 31 * result + width
             result = 31 * result + height
             result = 31 * result + isAlwaysOnTop.hashCode()
+            result = 31 * result + (title?.hashCode() ?: 0)
             result
         }
 
@@ -69,11 +71,12 @@ public class WindowsState(
             if (this.width != other.width) return false
             if (this.height != other.height) return false
             if (this.isAlwaysOnTop != other.isAlwaysOnTop) return false
+            if (this.title != other.title) return false
             return true
         }
 
         override fun toString(): String {
-            return "WindowState(x=$x, y=$y, width=$width, height=$height, isAlwaysOnTop=$isAlwaysOnTop)"
+            return "WindowState(x=$x, y=$y, width=$width, height=$height, isAlwaysOnTop=$isAlwaysOnTop, title=$title)"
         }
     }
 
@@ -95,7 +98,8 @@ internal class WindowsStateEncoder : OrchestrationStateEncoder<WindowsState> {
                 "y" to encodeByteArray { writeInt(windowState.y) },
                 "width" to encodeByteArray { writeInt(windowState.width) },
                 "height" to encodeByteArray { writeInt(windowState.height) },
-                "isAlwaysOnTop" to encodeByteArray { writeBoolean(windowState.isAlwaysOnTop) }
+                "isAlwaysOnTop" to encodeByteArray { writeBoolean(windowState.isAlwaysOnTop) },
+                "title" to windowState.title?.encodeToByteArray(),
             )
         }
     }
@@ -111,7 +115,9 @@ internal class WindowsStateEncoder : OrchestrationStateEncoder<WindowsState> {
                     width = fields["width"]?.decode { readInt() } ?: error("Missing field `width`"),
                     height = fields["height"]?.decode { readInt() } ?: error("Missing field `height`"),
                     isAlwaysOnTop = fields["isAlwaysOnTop"]?.decode { readBoolean() }
-                        ?: error("Missing field `isAlwaysOnTop`")
+                        ?: error("Missing field `isAlwaysOnTop`"),
+                    // Missing or absent title decodes to null (forward-compat with older runtimes).
+                    title = fields["title"]?.decodeToString(),
                 )
             }
         }

--- a/hot-reload-devtools-api/src/test/kotlin/WindowsStateTest.kt
+++ b/hot-reload-devtools-api/src/test/kotlin/WindowsStateTest.kt
@@ -21,11 +21,24 @@ class WindowsStateTest {
         val nonEmpty = WindowsState(
             mapOf(
                 WindowId.create() to WindowsState.WindowState(
-                    x = 1, y = 2, width = 3, height = 4, isAlwaysOnTop = true
+                    x = 1, y = 2, width = 3, height = 4, isAlwaysOnTop = true, title = "Main",
                 )
             )
         )
 
         assertEquals(nonEmpty, encoder.decode(encoder.encode(nonEmpty)).getOrThrow())
+    }
+
+    @Test
+    fun `test - title defaults to null when omitted`() {
+        val state = WindowsState(
+            mapOf(
+                WindowId.create() to WindowsState.WindowState(
+                    x = 1, y = 2, width = 3, height = 4, isAlwaysOnTop = false,
+                )
+            )
+        )
+        val roundTripped = encoder.decode(encoder.encode(state)).getOrThrow()
+        assertEquals(null, roundTripped.windows.values.single().title)
     }
 }

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -119,10 +119,11 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
         addTool(
             name = "list_windows",
             description = "List all currently registered Compose application windows. " +
-                "Returns a JSON array with one entry per window containing 'id', 'x', 'y', " +
-                "'width', and 'height'. Use a window 'id' as the 'window_id' parameter on " +
-                "window-targeting tools (take_screenshot, get_semantic_tree, click, ...) " +
-                "to target a specific window."
+                "Returns a JSON array with one entry per window containing 'id', 'title', " +
+                "'x', 'y', 'width', and 'height'. 'title' is the window title set by the " +
+                "application (empty string when none). Use a window 'id' as the 'window_id' " +
+                "parameter on window-targeting tools (take_screenshot, get_semantic_tree, " +
+                "click, ...) to target a specific window."
         ) { _ ->
             handleListWindows(orchestration)
         }
@@ -270,6 +271,7 @@ private suspend fun handleListWindows(orchestration: StateFlow<OrchestrationHand
         windows.forEach { (id, state) ->
             addJsonObject {
                 put("id", id.value)
+                put("title", state.title)
                 put("x", state.x)
                 put("y", state.y)
                 put("width", state.width)

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -26,7 +26,10 @@ import kotlinx.io.asSource
 import kotlinx.io.buffered
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
@@ -34,8 +37,10 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import org.jetbrains.compose.devtools.api.ReloadCountState
 import org.jetbrains.compose.devtools.api.ReloadState
+import org.jetbrains.compose.devtools.api.WindowsState
 import org.jetbrains.compose.reload.DelicateHotReloadApi
 import org.jetbrains.compose.reload.core.HOT_RELOAD_VERSION
+import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.createLogger
 import org.jetbrains.compose.reload.core.debug
 import org.jetbrains.compose.reload.core.info
@@ -71,6 +76,8 @@ private val NodeId = Property("nodeId", "integer",
     description = "Semantic node id as reported by 'get_semantic_tree'.")
 private val ScrollContainerNodeId = Property("nodeId", "integer",
     description = "Semantic node id of the scrollable container as reported by 'get_semantic_tree'.")
+private val WindowIdParam = Property("window_id", "string",
+    description = "Window ID as returned by 'list_windows'. Defaults to the first registered window.")
 
 /** Builds a [ToolSchema] from [properties]; by default all of them are required. */
 private fun toolSchema(
@@ -110,11 +117,23 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
         }
 
         addTool(
+            name = "list_windows",
+            description = "List all currently registered Compose application windows. " +
+                "Returns a JSON array with one entry per window containing 'id', 'x', 'y', " +
+                "'width', and 'height'. Use a window 'id' as the 'window_id' parameter on " +
+                "window-targeting tools (take_screenshot, get_semantic_tree, click, ...) " +
+                "to target a specific window."
+        ) { _ ->
+            handleListWindows(orchestration)
+        }
+
+        addTool(
             name = "take_screenshot",
             description = "Take a screenshot of the running Compose application window. " +
-                "Use the 'status' tool first to check if the application is connected."
-        ) { _ ->
-            handleTakeScreenshot(orchestration)
+                "Use the 'status' tool first to check if the application is connected.",
+            inputSchema = toolSchema(WindowIdParam, required = emptyList())
+        ) { request ->
+            handleTakeScreenshot(orchestration, request)
         }
 
         addTool(
@@ -122,16 +141,17 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             description = "Get the Compose semantic/accessibility tree of the running application. " +
                 "Returns a JSON tree describing the UI component hierarchy with roles, names, " +
                 "descriptions, states (enabled, visible, focused, etc.), and bounds. " +
-                "Use the 'status' tool first to check if the application is connected."
-        ) { _ ->
-            handleGetSemanticTree(orchestration)
+                "Use the 'status' tool first to check if the application is connected.",
+            inputSchema = toolSchema(WindowIdParam, required = emptyList())
+        ) { request ->
+            handleGetSemanticTree(orchestration, request)
         }
 
         addTool(
             name = "click",
             description = "Click a UI element. The element must have 'onClick' in its " +
                 "'actions' list as reported by 'get_semantic_tree'.",
-            inputSchema = toolSchema(NodeId)
+            inputSchema = toolSchema(NodeId, WindowIdParam, required = listOf(NodeId.name))
         ) { request ->
             handleUIAction(orchestration, request) { UIAction.Click }
         }
@@ -140,7 +160,7 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             name = "long_click",
             description = "Long-click (long press) a UI element. The element must have " +
                 "'onLongClick' in its 'actions' list as reported by 'get_semantic_tree'.",
-            inputSchema = toolSchema(NodeId)
+            inputSchema = toolSchema(NodeId, WindowIdParam, required = listOf(NodeId.name))
         ) { request ->
             handleUIAction(orchestration, request) { UIAction.LongClick }
         }
@@ -153,6 +173,8 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
                 NodeId,
                 Property("text", "string",
                     description = "Text to set as the content of the editable field."),
+                WindowIdParam,
+                required = listOf(NodeId.name, "text"),
             )
         ) { request ->
             handleUIAction(orchestration, request) { args ->
@@ -173,6 +195,7 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
                     description = "Horizontal scroll delta in logical pixels (positive = right)."),
                 Property("deltaY", "number",
                     description = "Vertical scroll delta in logical pixels (positive = down)."),
+                WindowIdParam,
                 required = listOf("nodeId"),
             )
         ) { request ->
@@ -192,6 +215,8 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
                 ScrollContainerNodeId,
                 Property("index", "integer",
                     description = "Zero-based index of the item to scroll to."),
+                WindowIdParam,
+                required = listOf(NodeId.name, "index"),
             )
         ) { request ->
             handleUIAction(orchestration, request) { args ->
@@ -232,15 +257,47 @@ private suspend fun handleStatus(orchestration: StateFlow<OrchestrationHandle?>)
     )
 }
 
-private suspend fun handleTakeScreenshot(orchestration: StateFlow<OrchestrationHandle?>): CallToolResult {
+private suspend fun handleListWindows(orchestration: StateFlow<OrchestrationHandle?>): CallToolResult {
+    val handle = orchestration.value
+        ?: return CallToolResult(
+            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
+            isError = true
+        ).also { logger.info { "list_windows: no application connected" } }
+
+    val windows = handle.states.get(WindowsState).value.windows
+    logger.debug { "list_windows: ${windows.size} window(s)" }
+    val json = buildJsonArray {
+        windows.forEach { (id, state) ->
+            addJsonObject {
+                put("id", id.value)
+                put("x", state.x)
+                put("y", state.y)
+                put("width", state.width)
+                put("height", state.height)
+            }
+        }
+    }
+    return CallToolResult(content = listOf(TextContent(json.toString())))
+}
+
+private suspend fun handleTakeScreenshot(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    request: CallToolRequest,
+): CallToolResult {
     val handle = orchestration.value
         ?: return CallToolResult(
             content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
             isError = true
         ).also { logger.info { "take_screenshot: no application connected" } }
 
+    val resolvedId = try {
+        resolveWindowId(handle, request.arguments)
+    } catch (e: IllegalArgumentException) {
+        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
+    }
+
     return try {
-        val request = ScreenshotRequest()
+        val request = ScreenshotRequest(windowId = resolvedId)
         logger.info { "take_screenshot: sending request '${request.messageId}'" }
         val screenshot = handle.requestResponse<ScreenshotResult>(request) {
             it.screenshotRequestId == request.messageId
@@ -276,15 +333,24 @@ private suspend fun handleTakeScreenshot(orchestration: StateFlow<OrchestrationH
     }
 }
 
-private suspend fun handleGetSemanticTree(orchestration: StateFlow<OrchestrationHandle?>): CallToolResult {
+private suspend fun handleGetSemanticTree(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    request: CallToolRequest,
+): CallToolResult {
     val handle = orchestration.value
         ?: return CallToolResult(
             content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
             isError = true
         ).also { logger.info { "get_semantic_tree: no application connected" } }
 
+    val resolvedId = try {
+        resolveWindowId(handle, request.arguments)
+    } catch (e: IllegalArgumentException) {
+        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
+    }
+
     return try {
-        val request = SemanticTreeRequest()
+        val request = SemanticTreeRequest(windowId = resolvedId)
         logger.info { "get_semantic_tree: sending request '${request.messageId}'" }
         val semanticTree = handle.requestResponse<SemanticTreeResult>(request) {
             it.semanticTreeRequestId == request.messageId
@@ -336,8 +402,14 @@ private suspend fun handleUIAction(
         )
     }
 
+    val resolvedId = try {
+        resolveWindowId(handle, args)
+    } catch (e: IllegalArgumentException) {
+        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
+    }
+
     return try {
-        val uiActionRequest = UIActionRequest(nodeId = nodeId, action = action)
+        val uiActionRequest = UIActionRequest(nodeId = nodeId, action = action, windowId = resolvedId)
         logger.info { "${request.name}: sending request '${uiActionRequest.messageId}' nodeId=$nodeId action=$action" }
         val actionResult = handle.requestResponse<UIActionResult>(uiActionRequest) {
             it.uiActionRequestId == uiActionRequest.messageId
@@ -368,6 +440,17 @@ private suspend fun handleUIAction(
             isError = true
         )
     }
+}
+
+private suspend fun resolveWindowId(handle: OrchestrationHandle, args: JsonObject?): WindowId? {
+    val windows = handle.states.get(WindowsState).value.windows
+    val explicit = args?.get("window_id")?.jsonPrimitive?.contentOrNull
+    if (explicit != null) {
+        val id = WindowId(explicit)
+        require(id in windows) { "Window '$explicit' not found" }
+        return id
+    }
+    return windows.keys.firstOrNull()
 }
 
 /**

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -496,8 +496,8 @@ class McpServerTest {
         }
     }
 
-    private fun windowState(x: Int, y: Int, width: Int, height: Int): WindowState =
-        WindowState(x = x, y = y, width = width, height = height, isAlwaysOnTop = false)
+    private fun windowState(x: Int, y: Int, width: Int, height: Int, title: String? = null): WindowState =
+        WindowState(x = x, y = y, width = width, height = height, isAlwaysOnTop = false, title = title)
 
     @Test
     fun `test - list_windows returns error when disconnected`() = runTest(timeout = 10.seconds) {
@@ -540,17 +540,83 @@ class McpServerTest {
 
             server.update(WindowsState) {
                 WindowsState(linkedMapOf(
-                    WindowId("w-1") to windowState(x = 10, y = 20, width = 100, height = 200),
-                    WindowId("w-2") to windowState(x = 30, y = 40, width = 300, height = 400),
+                    WindowId("w-1") to windowState(x = 10, y = 20, width = 100, height = 200, title = "Main"),
+                    WindowId("w-2") to windowState(x = 30, y = 40, width = 300, height = 400, title = "Settings"),
                 ))
             }
 
             val text = awaitWindows(client, expectedCount = 2)
             assertEquals(
-                """[{"id":"w-1","x":10,"y":20,"width":100,"height":200},""" +
-                    """{"id":"w-2","x":30,"y":40,"width":300,"height":400}]""",
+                """[{"id":"w-1","title":"Main","x":10,"y":20,"width":100,"height":200},""" +
+                    """{"id":"w-2","title":"Settings","x":30,"y":40,"width":300,"height":400}]""",
                 text,
             )
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - list_windows serializes null title as JSON null`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(x = 0, y = 0, width = 100, height = 100, title = null),
+                ))
+            }
+
+            val text = awaitWindows(client, expectedCount = 1)
+            assertEquals(
+                """[{"id":"w-1","title":null,"x":0,"y":0,"width":100,"height":100}]""",
+                text,
+            )
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - list_windows reflects title changes`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(x = 0, y = 0, width = 100, height = 100, title = "Initial"),
+                ))
+            }
+            val before = awaitWindows(client, expectedCount = 1)
+            assertTrue(before.contains(""""title":"Initial""""), "Expected initial title, got: $before")
+
+            server.update(WindowsState) { current ->
+                val id = WindowId("w-1")
+                val old = current.windows.getValue(id)
+                WindowsState(linkedMapOf(id to windowState(
+                    x = old.x, y = old.y, width = old.width, height = old.height, title = "Renamed",
+                )))
+            }
+
+            val deadline = System.currentTimeMillis() + 5_000L
+            while (true) {
+                val text = (client.callTool("list_windows", emptyMap()).content.first() as TextContent).text
+                if (text.contains(""""title":"Renamed"""")) break
+                if (System.currentTimeMillis() > deadline) {
+                    throw AssertionError("Timed out waiting for title rename. Last: $text")
+                }
+                Thread.sleep(10)
+            }
         } finally {
             server.close()
         }

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -22,6 +22,9 @@ import kotlinx.io.asSource
 import kotlinx.io.buffered
 import org.jetbrains.compose.devtools.api.ReloadCountState
 import org.jetbrains.compose.devtools.api.ReloadState
+import org.jetbrains.compose.devtools.api.WindowsState
+import org.jetbrains.compose.devtools.api.WindowsState.WindowState
+import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.awaitOrThrow
 import org.jetbrains.compose.reload.core.getOrThrow
 import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
@@ -467,6 +470,305 @@ class McpServerTest {
                 """{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":1,"failedReloads":0}""",
                 text,
             )
+        } finally {
+            server.close()
+        }
+    }
+
+    /**
+     * Polls the `list_windows` tool until the returned JSON array contains
+     * exactly [expectedCount] entries, or fails after 5 real-time seconds.
+     */
+    private suspend fun awaitWindows(client: Client, expectedCount: Int): String {
+        val deadline = System.currentTimeMillis() + 5_000L
+        val expectedPrefix = "[" // distinguish from an error response
+        while (true) {
+            val result = client.callTool("list_windows", emptyMap())
+            val text = (result.content.first() as TextContent).text
+            if (text.startsWith(expectedPrefix)) {
+                val count = if (text == "[]") 0 else text.count { it == '{' }
+                if (count == expectedCount) return text
+            }
+            if (System.currentTimeMillis() > deadline) {
+                throw AssertionError("Timed out waiting for $expectedCount window(s). Last: $text")
+            }
+            Thread.sleep(10)
+        }
+    }
+
+    private fun windowState(x: Int, y: Int, width: Int, height: Int): WindowState =
+        WindowState(x = x, y = y, width = width, height = height, isAlwaysOnTop = false)
+
+    @Test
+    fun `test - list_windows returns error when disconnected`() = runTest(timeout = 10.seconds) {
+        val orchestration = MutableStateFlow<OrchestrationHandle?>(null)
+        val client = createMcpClient(orchestration)
+
+        val result = client.callTool("list_windows", emptyMap())
+        assertEquals(true, result.isError)
+        val text = (result.content.first() as TextContent).text
+        assertTrue(text.contains("No application is currently connected"))
+    }
+
+    @Test
+    fun `test - list_windows returns empty array when no windows are registered`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("list_windows", emptyMap())
+            val text = (result.content.first() as TextContent).text
+            assertEquals("[]", text)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - list_windows returns registered windows in insertion order`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(x = 10, y = 20, width = 100, height = 200),
+                    WindowId("w-2") to windowState(x = 30, y = 40, width = 300, height = 400),
+                ))
+            }
+
+            val text = awaitWindows(client, expectedCount = 2)
+            assertEquals(
+                """[{"id":"w-1","x":10,"y":20,"width":100,"height":200},""" +
+                    """{"id":"w-2","x":30,"y":40,"width":300,"height":400}]""",
+                text,
+            )
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - take_screenshot forwards explicit window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedWindowId: WindowId? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<ScreenshotRequest>().first()
+                receivedWindowId = request.windowId
+                server.send(ScreenshotResult(
+                    screenshotRequestId = request.messageId,
+                    format = "png",
+                    data = ByteArray(1) { 0xFF.toByte() }
+                ))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                    WindowId("w-2") to windowState(0, 0, 200, 200),
+                ))
+            }
+            awaitWindows(client, expectedCount = 2)
+
+            val result = client.callTool("take_screenshot", mapOf("window_id" to "w-2"))
+            assertNotEquals(true, result.isError)
+            assertEquals(WindowId("w-2"), receivedWindowId)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - take_screenshot defaults to first registered window`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedWindowId: WindowId? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<ScreenshotRequest>().first()
+                receivedWindowId = request.windowId
+                server.send(ScreenshotResult(
+                    screenshotRequestId = request.messageId,
+                    format = "png",
+                    data = ByteArray(1) { 0xFF.toByte() }
+                ))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                    WindowId("w-2") to windowState(0, 0, 200, 200),
+                ))
+            }
+            awaitWindows(client, expectedCount = 2)
+
+            val result = client.callTool("take_screenshot", emptyMap())
+            assertNotEquals(true, result.isError)
+            assertEquals(WindowId("w-1"), receivedWindowId)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - take_screenshot returns error for unknown window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                ))
+            }
+            awaitWindows(client, expectedCount = 1)
+
+            val result = client.callTool("take_screenshot", mapOf("window_id" to "ghost"))
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - get_semantic_tree forwards explicit window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedWindowId: WindowId? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<SemanticTreeRequest>().first()
+                receivedWindowId = request.windowId
+                server.send(SemanticTreeResult(semanticTreeRequestId = request.messageId, tree = "{}"))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                    WindowId("w-2") to windowState(0, 0, 200, 200),
+                ))
+            }
+            awaitWindows(client, expectedCount = 2)
+
+            val result = client.callTool("get_semantic_tree", mapOf("window_id" to "w-2"))
+            assertNotEquals(true, result.isError)
+            assertEquals(WindowId("w-2"), receivedWindowId)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - get_semantic_tree returns error for unknown window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                ))
+            }
+            awaitWindows(client, expectedCount = 1)
+
+            val result = client.callTool("get_semantic_tree", mapOf("window_id" to "ghost"))
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - click forwards explicit window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var receivedWindowId: WindowId? = null
+            launch {
+                val request = server.asFlow().filterIsInstance<UIActionRequest>().first()
+                receivedWindowId = request.windowId
+                server.send(UIActionResult(uiActionRequestId = request.messageId, isSuccess = true))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                    WindowId("w-2") to windowState(0, 0, 200, 200),
+                ))
+            }
+            awaitWindows(client, expectedCount = 2)
+
+            val result = client.callTool("click", mapOf("nodeId" to 7, "window_id" to "w-2"))
+            assertNotEquals(true, result.isError)
+            assertEquals(WindowId("w-2"), receivedWindowId)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - click returns error for unknown window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                ))
+            }
+            awaitWindows(client, expectedCount = 1)
+
+            val result = client.callTool("click", mapOf("nodeId" to 7, "window_id" to "ghost"))
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
         } finally {
             server.close()
         }

--- a/hot-reload-orchestration/api/hot-reload-orchestration.api
+++ b/hot-reload-orchestration/api/hot-reload-orchestration.api
@@ -423,6 +423,9 @@ public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessa
 
 public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$ScreenshotRequest : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
 	public fun <init> ()V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getWindowId-cPrXUn0 ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$ScreenshotResult : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
@@ -439,6 +442,9 @@ public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessa
 
 public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$SemanticTreeRequest : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
 	public fun <init> ()V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getWindowId-cPrXUn0 ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$SemanticTreeResult : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
@@ -532,9 +538,12 @@ public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessa
 
 public final class org/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIActionRequest : org/jetbrains/compose/reload/orchestration/OrchestrationMessage {
 	public fun <init> (ILorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction;)V
+	public synthetic fun <init> (ILorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationMessage$UIAction;
 	public final fun getNodeId ()I
+	public final fun getWindowId-cPrXUn0 ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 

--- a/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationMessage.kt
+++ b/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/OrchestrationMessage.kt
@@ -308,7 +308,9 @@ internal constructor() : OrchestrationPackage(), Serializable {
      * The response is [ScreenshotResult] with [ScreenshotResult.screenshotRequestId]
      * matching this request's [messageId].
      */
-    public class ScreenshotRequest : OrchestrationMessage() {
+    public class ScreenshotRequest @JvmOverloads constructor(
+        public val windowId: WindowId? = null,
+    ) : OrchestrationMessage() {
         internal companion object {
             @Suppress("unused")
             internal const val serialVersionUID: Long = 0L
@@ -596,7 +598,9 @@ internal constructor() : OrchestrationPackage(), Serializable {
     /**
      * Requests the application to capture and send the Compose semantic tree.
      */
-    public class SemanticTreeRequest : OrchestrationMessage() {
+    public class SemanticTreeRequest @JvmOverloads constructor(
+        public val windowId: WindowId? = null,
+    ) : OrchestrationMessage() {
         internal companion object {
             @Suppress("unused")
             internal const val serialVersionUID: Long = 0L
@@ -676,9 +680,10 @@ internal constructor() : OrchestrationPackage(), Serializable {
      * Requests the application to perform a [UIAction] on the semantic node with the given [nodeId].
      * The node ID corresponds to the `id` field returned by [SemanticTreeRequest] / [SemanticTreeResult].
      */
-    public class UIActionRequest(
+    public class UIActionRequest @JvmOverloads constructor(
         public val nodeId: Int,
         public val action: UIAction,
+        public val windowId: WindowId? = null,
     ) : OrchestrationMessage() {
         internal companion object {
             @Suppress("unused")
@@ -688,6 +693,7 @@ internal constructor() : OrchestrationPackage(), Serializable {
         override fun hashCode(): Int {
             var hashCode = nodeId.hashCode()
             hashCode = 31 * hashCode + action.hashCode()
+            hashCode = 31 * hashCode + (windowId?.hashCode() ?: 0)
             return hashCode
         }
 
@@ -696,6 +702,7 @@ internal constructor() : OrchestrationPackage(), Serializable {
             if (other !is UIActionRequest) return false
             if (other.nodeId != nodeId) return false
             if (other.action != action) return false
+            if (other.windowId != windowId) return false
             return true
         }
     }

--- a/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/orchestrationMessageEncoders.kt
+++ b/hot-reload-orchestration/src/main/kotlin/org/jetbrains/compose/reload/orchestration/orchestrationMessageEncoders.kt
@@ -207,9 +207,16 @@ internal class TakeScreenshotRequestEncoder : OrchestrationMessageEncoder<Orches
 internal class SemanticTreeRequestEncoder : OrchestrationMessageEncoder<OrchestrationMessage.SemanticTreeRequest> {
     override val messageType: Type<OrchestrationMessage.SemanticTreeRequest> = type()
     override val messageClassifier = classifier("SemanticTreeRequest")
-    override fun encode(message: OrchestrationMessage.SemanticTreeRequest): ByteArray = byteArrayOf()
-    override fun decode(data: ByteArray): Try<OrchestrationMessage.SemanticTreeRequest> =
-        OrchestrationMessage.SemanticTreeRequest().toLeft()
+    override fun encode(message: OrchestrationMessage.SemanticTreeRequest): ByteArray = encodeByteArray {
+        writeFields("windowId" to message.windowId?.value?.encodeToByteArray())
+    }
+
+    override fun decode(data: ByteArray): Try<OrchestrationMessage.SemanticTreeRequest> = data.tryDecode {
+        val fields = readFields()
+        OrchestrationMessage.SemanticTreeRequest(
+            windowId = fields["windowId"]?.decodeToString()?.let(::WindowId),
+        )
+    }
 }
 
 internal class SemanticTreeResultEncoder : OrchestrationMessageEncoder<OrchestrationMessage.SemanticTreeResult> {
@@ -240,6 +247,7 @@ internal class UIActionRequestEncoder : OrchestrationMessageEncoder<Orchestratio
         writeFields(
             "nodeId" to encodeByteArray { writeInt(message.nodeId) },
             "action" to encodeUIAction(message.action),
+            "windowId" to message.windowId?.value?.encodeToByteArray(),
         )
     }
 
@@ -248,6 +256,7 @@ internal class UIActionRequestEncoder : OrchestrationMessageEncoder<Orchestratio
         OrchestrationMessage.UIActionRequest(
             nodeId = fields.requireField("nodeId").decode { readInt() },
             action = fields.requireField("action").decode { readUIAction() },
+            windowId = fields["windowId"]?.decodeToString()?.let(::WindowId),
         )
     }
 
@@ -450,9 +459,16 @@ internal class ScreenshotEncoder : OrchestrationMessageEncoder<OrchestrationMess
 internal class ScreenshotRequestEncoder : OrchestrationMessageEncoder<OrchestrationMessage.ScreenshotRequest> {
     override val messageType: Type<OrchestrationMessage.ScreenshotRequest> = type()
     override val messageClassifier = classifier("ScreenshotRequest")
-    override fun encode(message: OrchestrationMessage.ScreenshotRequest): ByteArray = byteArrayOf()
-    override fun decode(data: ByteArray): Try<OrchestrationMessage.ScreenshotRequest> =
-        OrchestrationMessage.ScreenshotRequest().toLeft()
+    override fun encode(message: OrchestrationMessage.ScreenshotRequest): ByteArray = encodeByteArray {
+        writeFields("windowId" to message.windowId?.value?.encodeToByteArray())
+    }
+
+    override fun decode(data: ByteArray): Try<OrchestrationMessage.ScreenshotRequest> = data.tryDecode {
+        val fields = readFields()
+        OrchestrationMessage.ScreenshotRequest(
+            windowId = fields["windowId"]?.decodeToString()?.let(::WindowId),
+        )
+    }
 }
 
 internal class ScreenshotResultEncoder : OrchestrationMessageEncoder<OrchestrationMessage.ScreenshotResult> {

--- a/hot-reload-orchestration/src/test/kotlin/org/jetbrains/compose/reload/orchestration/SerializationTest.kt
+++ b/hot-reload-orchestration/src/test/kotlin/org/jetbrains/compose/reload/orchestration/SerializationTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 
 class SerializationTest {
     @Test
@@ -189,6 +190,151 @@ class SerializationTest {
     @Test
     fun `test - screenshot`() = testEncodeDecodeEquals(
         OrchestrationMessage.Screenshot("xyz", byteArrayOf(1, 2, 3))
+    )
+
+    @Test
+    fun `test - screenshot request - null windowId`() {
+        val request = OrchestrationMessage.ScreenshotRequest()
+        val decoded = assertIs<OrchestrationMessage.ScreenshotRequest>(
+            request.encodeToFrame(current).decodePackage()
+        )
+        assertEquals(request.messageId, decoded.messageId)
+        assertEquals(null, decoded.windowId)
+    }
+
+    @Test
+    fun `test - screenshot request - with windowId`() {
+        val request = OrchestrationMessage.ScreenshotRequest(WindowId("some window id"))
+        val decoded = assertIs<OrchestrationMessage.ScreenshotRequest>(
+            request.encodeToFrame(current).decodePackage()
+        )
+        assertEquals(request.messageId, decoded.messageId)
+        assertEquals(WindowId("some window id"), decoded.windowId)
+    }
+
+    @Test
+    fun `test - screenshot result - success`() = testEncodeDecodeEquals(
+        OrchestrationMessage.ScreenshotResult(
+            screenshotRequestId = OrchestrationMessageId.random(),
+            format = "png",
+            data = byteArrayOf(1, 2, 3, 4),
+            isSuccess = true,
+            errorMessage = null,
+        )
+    )
+
+    @Test
+    fun `test - screenshot result - failure`() = testEncodeDecodeEquals(
+        OrchestrationMessage.ScreenshotResult(
+            screenshotRequestId = OrchestrationMessageId.random(),
+            format = "",
+            data = ByteArray(0),
+            isSuccess = false,
+            errorMessage = "capture failed",
+        )
+    )
+
+    @Test
+    fun `test - semantic tree request - null windowId`() {
+        val request = OrchestrationMessage.SemanticTreeRequest()
+        val decoded = assertIs<OrchestrationMessage.SemanticTreeRequest>(
+            request.encodeToFrame(current).decodePackage()
+        )
+        assertEquals(request.messageId, decoded.messageId)
+        assertEquals(null, decoded.windowId)
+    }
+
+    @Test
+    fun `test - semantic tree request - with windowId`() {
+        val request = OrchestrationMessage.SemanticTreeRequest(WindowId("w-2"))
+        val decoded = assertIs<OrchestrationMessage.SemanticTreeRequest>(
+            request.encodeToFrame(current).decodePackage()
+        )
+        assertEquals(request.messageId, decoded.messageId)
+        assertEquals(WindowId("w-2"), decoded.windowId)
+    }
+
+    @Test
+    fun `test - semantic tree result`() = testEncodeDecodeEquals(
+        OrchestrationMessage.SemanticTreeResult(
+            semanticTreeRequestId = OrchestrationMessageId.random(),
+            tree = """{"role":"Button","children":[]}""",
+        )
+    )
+
+    @Test
+    fun `test - ui action request - click - null windowId`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionRequest(nodeId = 7, action = OrchestrationMessage.UIAction.Click)
+    )
+
+    @Test
+    fun `test - ui action request - click - with windowId`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionRequest(
+            nodeId = 7,
+            action = OrchestrationMessage.UIAction.Click,
+            windowId = WindowId("w-1"),
+        )
+    )
+
+    @Test
+    fun `test - ui action request - long click`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionRequest(
+            nodeId = 3,
+            action = OrchestrationMessage.UIAction.LongClick,
+            windowId = WindowId("w-1"),
+        )
+    )
+
+    @Test
+    fun `test - ui action request - set text`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionRequest(
+            nodeId = 11,
+            action = OrchestrationMessage.UIAction.SetText("hello world"),
+        )
+    )
+
+    @Test
+    fun `test - ui action request - scroll by`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionRequest(
+            nodeId = 5,
+            action = OrchestrationMessage.UIAction.ScrollBy(deltaX = 10f, deltaY = -20.5f),
+        )
+    )
+
+    @Test
+    fun `test - ui action request - scroll to index`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionRequest(
+            nodeId = 5,
+            action = OrchestrationMessage.UIAction.ScrollToIndex(42),
+        )
+    )
+
+    @Test
+    fun `test - ui action request - equals differs by windowId`() {
+        val a = OrchestrationMessage.UIActionRequest(7, OrchestrationMessage.UIAction.Click, WindowId("w-1"))
+        val b = OrchestrationMessage.UIActionRequest(7, OrchestrationMessage.UIAction.Click, WindowId("w-2"))
+        val c = OrchestrationMessage.UIActionRequest(7, OrchestrationMessage.UIAction.Click, null)
+        assertNotEquals(a, b)
+        assertNotEquals(a, c)
+        assertNotEquals(b, c)
+    }
+
+    @Test
+    fun `test - ui action result - success`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionResult(
+            uiActionRequestId = OrchestrationMessageId.random(),
+            isSuccess = true,
+            errorMessage = null,
+        )
+    )
+
+    @Test
+    fun `test - ui action result - failure`() = testEncodeDecodeEquals(
+        OrchestrationMessage.UIActionResult(
+            uiActionRequestId = OrchestrationMessageId.random(),
+            isSuccess = false,
+            errorMessage = "Node 7 not found",
+        )
     )
 
     @Test

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.DialogWindowScope
 import androidx.compose.ui.window.FrameWindowScope
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.update
 import org.jetbrains.compose.reload.InternalHotReloadApi
@@ -75,21 +76,30 @@ public fun DevelopmentEntryPoint(
 
     if (window != null) {
         LaunchedEffect(Unit) {
-            orchestration.asFlow().filterIsInstance<ScreenshotRequest>().collect { request ->
-                handleScreenshotRequest(request, window).sendAsync()
-            }
+            orchestration.asFlow()
+                .filterIsInstance<ScreenshotRequest>()
+                .filter { request -> request.windowId == null || request.windowId == windowId }
+                .collect { request ->
+                    handleScreenshotRequest(request, window).sendAsync()
+                }
         }
 
         LaunchedEffect(Unit) {
-            orchestration.asFlow().filterIsInstance<SemanticTreeRequest>().collect { request ->
-                handleSemanticTreeRequest(request, window).sendAsync()
-            }
+            orchestration.asFlow()
+                .filterIsInstance<SemanticTreeRequest>()
+                .filter { request -> request.windowId == null || request.windowId == windowId }
+                .collect { request ->
+                    handleSemanticTreeRequest(request, window).sendAsync()
+                }
         }
 
         LaunchedEffect(Unit) {
-            orchestration.asFlow().filterIsInstance<UIActionRequest>().collect { request ->
-                handleUIActionRequest(request, window).sendAsync()
-            }
+            orchestration.asFlow()
+                .filterIsInstance<UIActionRequest>()
+                .filter { request -> request.windowId == null || request.windowId == windowId }
+                .collect { request ->
+                    handleUIActionRequest(request, window).sendAsync()
+                }
         }
     }
 

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/window.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/window.kt
@@ -21,11 +21,13 @@ import org.jetbrains.compose.reload.core.createLogger
 import org.jetbrains.compose.reload.core.trace
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ApplicationWindowPositioned
+import java.awt.Frame
 import java.awt.Window
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.beans.PropertyChangeListener
 
 
 private val logger = createLogger()
@@ -52,7 +54,8 @@ internal fun startWindowManager(window: Window): WindowId {
             windowState.trySendBlocking(
                 WindowState(
                     x = window.x, y = window.y, width = window.width, height = window.height,
-                    isAlwaysOnTop = window.isAlwaysOnTop
+                    isAlwaysOnTop = window.isAlwaysOnTop,
+                    title = (window as? Frame)?.title,
                 )
             )
 
@@ -131,10 +134,16 @@ internal fun startWindowManager(window: Window): WindowId {
             }
         }
 
+        val titleListener = PropertyChangeListener { event ->
+            logger.trace { "$windowId: title changed: '${event.oldValue}' -> '${event.newValue}'" }
+            if (window.isVisible) broadcastActiveState()
+        }
+
         window.addWindowListener(windowListener)
         window.addWindowStateListener(windowListener)
         window.addWindowFocusListener(windowListener)
         window.addComponentListener(componentListener)
+        window.addPropertyChangeListener("title", titleListener)
 
         object : RememberObserver {
             override fun onRemembered() {}
@@ -143,6 +152,7 @@ internal fun startWindowManager(window: Window): WindowId {
             override fun onForgotten() {
                 window.removeWindowListener(windowListener)
                 window.removeComponentListener(componentListener)
+                window.removePropertyChangeListener("title", titleListener)
                 broadcastGone()
                 windowState.close()
             }

--- a/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/MultiWindowScreenshotIntegrationTest.kt
+++ b/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/MultiWindowScreenshotIntegrationTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024-2026 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.tests
+
+import kotlinx.coroutines.channels.consume
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import org.jetbrains.compose.devtools.api.WindowsState
+import org.jetbrains.compose.reload.core.State
+import org.jetbrains.compose.reload.core.WindowId
+import org.jetbrains.compose.reload.core.asChannel
+import org.jetbrains.compose.reload.core.withAsyncTrace
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotResult
+import org.jetbrains.compose.reload.orchestration.asFlow
+import org.jetbrains.compose.reload.test.gradle.Headless
+import org.jetbrains.compose.reload.test.gradle.HotReloadTest
+import org.jetbrains.compose.reload.test.gradle.HotReloadTestFixture
+import org.jetbrains.compose.reload.test.gradle.initialSourceCode
+import org.jetbrains.compose.reload.test.gradle.readImage
+import org.jetbrains.compose.reload.utils.HostIntegrationTest
+import org.jetbrains.compose.reload.utils.QuickTest
+import org.jetbrains.skia.Bitmap
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class MultiWindowScreenshotIntegrationTest {
+
+    private val twoWindowSource = """
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.fillMaxSize
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
+        import androidx.compose.ui.window.*
+
+        fun main() {
+            application {
+                Window(
+                    onCloseRequest = ::exitApplication,
+                    state = WindowState(width = 200.dp, height = 100.dp),
+                    undecorated = true,
+                ) {
+                    Box(modifier = Modifier.background(Color.Red).fillMaxSize())
+                }
+                Window(
+                    onCloseRequest = ::exitApplication,
+                    state = WindowState(width = 200.dp, height = 100.dp),
+                    undecorated = true,
+                ) {
+                    Box(modifier = Modifier.background(Color.Blue).fillMaxSize())
+                }
+            }
+        }
+    """.trimIndent()
+
+    @Headless(false)
+    @HostIntegrationTest
+    @HotReloadTest
+    @QuickTest
+    fun `test - screenshot with explicit windowId targets that window`(
+        fixture: HotReloadTestFixture
+    ) = fixture.runTest {
+        assumeTrue(isInteractiveDesktopAvailable(), "Test requires an interactive desktop")
+        fixture.launchAckSender()
+
+        val windowsState = fixture.orchestration.states.get(WindowsState)
+        fixture initialSourceCode twoWindowSource
+        awaitWindows(windowsState, 2)
+
+        // The blue window is registered second by the source above.
+        val windowIds = windowsState.value.windows.keys.toList()
+        val redWidowsId = windowIds[1]
+        val blueWindowId = windowIds[1]
+
+        val request = ScreenshotRequest(windowId = blueWindowId)
+        val result = fixture.sendMessage(request) {
+            skipToMessage<ScreenshotResult> { it.screenshotRequestId == request.messageId }
+        }
+
+        assertTrue(result.isSuccess, "Screenshot failed: ${result.errorMessage}")
+        val image = result.data.readImage()
+        val color = Bitmap.makeFromImage(image).getColor(image.width / 2, image.height / 2)
+        assertDominantChannel(color, expected = Channel.Blue)
+    }
+
+    /**
+     * At the orchestration level, a `ScreenshotRequest` with `windowId = null` is intentionally
+     * broadcast to all registered windows — every window-side handler that sees `windowId == null`
+     * responds. The "default to first window" semantic lives one layer up in the MCP server
+     * ([`resolveWindowId`][org.jetbrains.compose.reload.mcp]) and is covered by `McpServerTest`.
+     * This test pins the wire-level contract so a future refactor that changes the filter
+     * accidentally fails loudly.
+     */
+    @Headless(false)
+    @HostIntegrationTest
+    @HotReloadTest
+    @QuickTest
+    fun `test - screenshot with null windowId broadcasts to both windows`(
+        fixture: HotReloadTestFixture
+    ) = fixture.runTest {
+        assumeTrue(isInteractiveDesktopAvailable(), "Test requires an interactive desktop")
+        fixture.launchAckSender()
+
+        val windowsState = fixture.orchestration.states.get(WindowsState)
+        fixture initialSourceCode twoWindowSource
+        awaitWindows(windowsState, 2)
+
+        val request = ScreenshotRequest(windowId = null)
+        val results = fixture.runTransaction {
+            request.send()
+            buildList {
+                add(skipToMessage<ScreenshotResult> { it.screenshotRequestId == request.messageId })
+                add(skipToMessage<ScreenshotResult> { it.screenshotRequestId == request.messageId })
+            }
+        }
+        assertEquals(2, results.size)
+        assertTrue(results.all { it.isSuccess }, "All responses must be successful")
+    }
+
+    @Headless(false)
+    @HostIntegrationTest
+    @HotReloadTest
+    @QuickTest
+    fun `test - screenshot with unknown windowId is dropped`(
+        fixture: HotReloadTestFixture
+    ) = fixture.runTest {
+        assumeTrue(isInteractiveDesktopAvailable(), "Test requires an interactive desktop")
+        fixture.launchAckSender()
+
+        val windowsState = fixture.orchestration.states.get(WindowsState)
+        fixture initialSourceCode twoWindowSource
+        awaitWindows(windowsState, 2)
+
+        val request = ScreenshotRequest(windowId = WindowId("does-not-exist"))
+        fixture.orchestration.send(request)
+
+        val received = withTimeoutOrNull(3.seconds) {
+            fixture.orchestration.asFlow()
+                .filterIsInstance<ScreenshotResult>()
+                .first { it.screenshotRequestId == request.messageId }
+        }
+        assertNull(received, "Expected no response for unknown windowId, got: $received")
+    }
+
+    private enum class Channel { Red, Blue }
+
+    private fun assertDominantChannel(argb: Int, expected: Channel) {
+        val r = (argb shr 16) and 0xFF
+        val g = (argb shr 8) and 0xFF
+        val b = argb and 0xFF
+        val ok = when (expected) {
+            Channel.Red -> r > 200 && g < 60 && b < 60
+            Channel.Blue -> b > 200 && r < 60 && g < 60
+        }
+        assertTrue(ok, "Expected $expected dominant, got R=$r G=$g B=$b (#${Integer.toHexString(argb)})")
+    }
+}
+
+private suspend fun awaitWindows(windowsState: State<WindowsState>, count: Int) =
+    withAsyncTrace("Await $count windows") {
+        windowsState.asChannel().consume {
+            while (true) {
+                if (receive().windows.size == count) break
+            }
+        }
+    }


### PR DESCRIPTION
## Multi-window support for MCP tools

### Summary

MCP window-targeting tools (`take_screenshot`, `get_semantic_tree`, `click`, `long_click`, `type_text`, `scroll`, `scroll_to_index`) were ambiguous with multiple Compose windows — they broadcast and collected whichever response arrived first, so AI agents had no way to pick a specific window.

This PR:

1. Adds a `list_windows` MCP tool so agents can discover registered windows.
2. Adds an optional `window_id` parameter to every window-targeting tool.
3. Changes the default (no `window_id`) to operate on the first registered window instead of broadcasting.
4. Adds a `title` field to `WindowsState.WindowState` so agents can differentiate windows by their on-screen title.

### Protocol changes

- `ScreenshotRequest`, `SemanticTreeRequest`, `UIActionRequest` now carry an optional `windowId: WindowId?` field. Encoders updated to round-trip the field using the same nullable pattern already used by `UIRendered`.
- Application-side handlers in `DevelopmentEntryPoint` filter requests: `request.windowId == null || request.windowId == windowId`. Unknown window IDs are simply dropped on the application side.
- `WindowsState.WindowState` gains a `title: String` field, populated from `java.awt.Frame.title` / `Dialog.title` and refreshed whenever the window title changes.
- Wire compatibility: an older application talking to a newer MCP server decodes `windowId = null` and falls back to the legacy broadcast behaviour. Acceptable for a dev tool.

### MCP server

- New `list_windows` tool returns a JSON array of `{id, title, x, y, width, height}` per window, in `WindowsState` insertion order. The `title` lets agents identify windows by what the user actually sees, not just opaque IDs.
- Resolution: explicit `window_id` is validated against `WindowsState.windows`; unknown IDs return `Window '<id>' not found`. Without a `window_id`, the server resolves to the first registered window before sending.

### Tests

| Layer | What was added |
|---|---|
| **Serialization** (`hot-reload-orchestration`) | 16 new tests in `SerializationTest.kt`: round-trip for `ScreenshotRequest`/`SemanticTreeRequest` (null + windowId), `ScreenshotResult`, `SemanticTreeResult`, all five `UIAction` subclasses via `UIActionRequest`, equality test (`windowId` differentiates), and `UIActionResult` success/failure. These six messages had **never** been covered — the gap predates this branch and was inherited from the original MCP commit. |
| **WindowsState** (`hot-reload-devtools-api`) | `WindowsStateTest` extended to round-trip the new `title` field. |
| **MCP server unit** (`hot-reload-mcp`) | 11 new tests in `McpServerTest.kt` + an `awaitWindows` helper: `list_windows` (disconnected / empty / insertion-ordered JSON including titles / live title updates); for `take_screenshot`, `get_semantic_tree`, `click` — explicit `window_id` is forwarded on the wire, default resolves to first window, unknown id returns `Window '<id>' not found`. |
| **Integration** (`tests/`) | 3 new non-headless tests in `MultiWindowScreenshotIntegrationTest.kt` driving a real two-window Compose app (red + blue): explicit `windowId` returns that window's pixels (centre-pixel channel check), `null` broadcasts to both windows (pins wire-level contract), unknown `windowId` is dropped (no response within 3 s). |


