### PR TITLE
[mcpserver] Startup failure fixes

### DIFF
--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
@@ -39,6 +39,10 @@ private val logger = createLogger()
 
 @OptIn(InternalHotReloadApi::class)
 fun main(args: Array<String>) {
+    // The MCP stdio transport reserves stdout for the JSON-RPC protocol.
+    val protocolOut = System.out
+    System.setOut(System.err)
+
     val pidFile = HotReloadEnvironment.pidFile
         ?: args.firstOrNull()?.let { Path.of(it) }
         ?: run {
@@ -52,7 +56,7 @@ fun main(args: Array<String>) {
         val orchestration = connectionLoop(pidFile)
             .stateIn(this, SharingStarted.Eagerly, null)
 
-        startMcpServer(orchestration)
+        startMcpServer(orchestration, protocolOut)
     }
 }
 

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
@@ -30,6 +30,7 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
 import org.jetbrains.compose.reload.orchestration.connectOrchestrationClient
 import java.nio.file.Path
 import java.nio.file.StandardWatchEventKinds
+import kotlin.io.path.createDirectories
 import kotlin.io.path.isRegularFile
 import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
@@ -92,6 +93,9 @@ internal suspend fun waitForOrchestrationPort(pidFile: Path): Int {
     val fileName = pidFile.fileName
 
     readOrchestrationPort(pidFile)?.let { return it }
+
+    // CMP-10258: The MCP server can start before the pid directory created.
+    directory.createDirectories()
 
     directory.fileSystem.newWatchService().use { watchService ->
         directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY)

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -55,16 +55,17 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIAction
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.UIActionResult
 import org.jetbrains.compose.reload.orchestration.asChannel
+import java.io.OutputStream
 import java.util.Base64
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 private val logger = createLogger()
 
-internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle?>) {
+internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle?>, protocolOut: OutputStream) {
     val transport = StdioServerTransport(
         inputStream = System.`in`.asSource().buffered(),
-        outputStream = System.out.asSink().buffered()
+        outputStream = protocolOut.asSink().buffered()
     )
     startMcpServer(orchestration, transport)
 }

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/ConnectionLifecycleTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/ConnectionLifecycleTest.kt
@@ -66,6 +66,32 @@ class ConnectionLifecycleTest {
     }
 
     @Test
+    fun `test - waitForOrchestrationPort waits when pid directory does not exist yet`() = runBlocking {
+        // CMP-10258: The MCP server can start before the pid directory exists. Watching a missing
+        // directory would fail, so waitForOrchestrationPort must create it first.
+        withTimeout(30.seconds) {
+            val tempDir = createTempDirectory("mcp-test")
+            try {
+                // Parent directory intentionally does not exist yet.
+                val pidFile = tempDir.resolve("build/run/test.pid")
+
+                val portDeferred = async(Dispatchers.IO) {
+                    waitForOrchestrationPort(pidFile)
+                }
+
+                // Give waitForOrchestrationPort time to create the directory and register the
+                // WatchService before the PID file is written.
+                delay(500.milliseconds)
+                pidFile.writePidFile(PidFileInfo(pid = 123, orchestrationPort = 8888))
+
+                assertEquals(8888, portDeferred.await())
+            } finally {
+                tempDir.toFile().deleteRecursively()
+            }
+        }
+    }
+
+    @Test
     fun `test - connectionLoop connects and detects disconnect`() = runTest(timeout = 30.seconds) {
         val tempDir = createTempDirectory("mcp-test")
         val server = startOrchestrationServer()


### PR DESCRIPTION
[CMP-10258](https://youtrack.jetbrains.com/issue/CMP-10258) fixes: 

 - The MCP server fails to start when there is no pid directory
 - Redirect System.out to stderr for MCP server to keep stdout for JSON-RPC transport