### PR TITLE
[mcpserver] Add `reload` tool to trigger hot reload

### DIFF
--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.asSink
 import kotlinx.io.asSource
@@ -47,6 +49,11 @@ import org.jetbrains.compose.reload.core.info
 import org.jetbrains.compose.reload.core.warn
 import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RecompileRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RecompileResult
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ReloadClassesRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ReloadClassesResult
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessageId
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotResult
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeResult
@@ -79,6 +86,11 @@ private val ScrollContainerNodeId = Property("nodeId", "integer",
     description = "Semantic node id of the scrollable container as reported by 'get_semantic_tree'.")
 private val WindowIdParam = Property("window_id", "string",
     description = "Window ID as returned by 'list_windows'. Defaults to the first registered window.")
+private val ReloadTimeoutParam = Property("timeout_seconds", "integer",
+    description = "Maximum seconds to wait for the reload to finish before returning a " +
+        "'still reloading' response (default $DEFAULT_RELOAD_TIMEOUT_SECONDS). Keep this at or below " +
+        "your own tool-call timeout; if it expires, poll the 'status' tool until 'reloadState' is no " +
+        "longer 'reloading'.")
 
 /** Builds a [ToolSchema] from [properties]; by default all of them are required. */
 private fun toolSchema(
@@ -115,6 +127,23 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
                 "Call this before take_screenshot to know if the application is available."
         ) { _ ->
             handleStatus(orchestration)
+        }
+
+        addTool(
+            name = "reload",
+            description = "Trigger a hot reload of the running Compose application: recompiles the " +
+                "project sources and reloads the changed classes into the live application without " +
+                "restarting it. Call this after editing source files to apply the changes. " +
+                "Returns {\"success\": true, \"reloaded\": true} when changed classes were reloaded, " +
+                "{\"success\": true, \"reloaded\": false} when compilation succeeded but nothing changed, " +
+                "and an error when compilation or the reload fails. " +
+                "If the reload does not finish within 'timeout_seconds', returns " +
+                "{\"status\": \"reloading\"} (not an error): the reload is still running, so poll the " +
+                "'status' tool until 'reloadState' is no longer 'reloading'. " +
+                "Use the 'status' tool first to check if the application is connected.",
+            inputSchema = toolSchema(ReloadTimeoutParam, required = emptyList())
+        ) { request ->
+            handleReload(orchestration, request)
         }
 
         addTool(
@@ -257,6 +286,103 @@ private suspend fun handleStatus(orchestration: StateFlow<OrchestrationHandle?>)
             put("failedReloads", count.failedReloads)
         }.toString()))
     )
+}
+
+/**
+ * Default time to wait for a reload to finish before telling the agent to poll 'status'.
+ * Overridable per call via the 'timeout_seconds' parameter. Kept within a typical MCP client's
+ * 60s request budget; a cold Gradle build may legitimately exceed it, hence the poll fallback.
+ */
+private const val DEFAULT_RELOAD_TIMEOUT_SECONDS = 60
+
+private suspend fun handleReload(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    toolRequest: CallToolRequest,
+): CallToolResult {
+    val handle = orchestration.value
+        ?: return CallToolResult(
+            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
+            isError = true
+        ).also { logger.info { "reload: no application connected" } }
+
+    val timeoutSeconds = (toolRequest.arguments?.get("timeout_seconds")?.jsonPrimitive?.intOrNull
+        ?: DEFAULT_RELOAD_TIMEOUT_SECONDS).coerceAtLeast(1)
+
+    val request = RecompileRequest()
+    logger.info { "reload: sending RecompileRequest '${request.messageId}' (timeout ${timeoutSeconds}s)" }
+
+    /*
+    The response channel is opened *before* sending the request to avoid missing a result
+    that could otherwise arrive before a cold flow starts collecting.
+
+    When the recompilation produces changed classes, the recompiler issues a ReloadClassesRequest
+    (whose id we don't know up front) and the application answers with a ReloadClassesResult
+    carrying that id. We capture the id of the first ReloadClassesRequest that follows our
+    RecompileRequest, then match its result exactly - this skips stale results from earlier reloads.
+    A build that produced no changed classes never issues a ReloadClassesRequest and is detected by
+    the RecompileResult for our request instead (sent only once the build, including any reload,
+    finished).
+     */
+    val channel = handle.asChannel()
+    val outcome = channel.consumeAsFlow().let { flow ->
+        handle.send(request)
+        withTimeoutOrNull(timeoutSeconds.seconds) {
+            var reloadRequestId: OrchestrationMessageId? = null
+            flow.mapNotNull { message ->
+                when (message) {
+                    is ReloadClassesRequest -> {
+                        if (reloadRequestId == null) reloadRequestId = message.messageId
+                        null
+                    }
+                    is ReloadClassesResult ->
+                        message.takeIf { reloadRequestId != null && it.reloadRequestId == reloadRequestId }
+                    is RecompileResult ->
+                        message.takeIf { it.recompileRequestId == request.messageId && reloadRequestId == null }
+                    else -> null
+                }
+            }.firstOrNull()
+        }
+    }
+
+    return when (outcome) {
+        is ReloadClassesResult -> if (outcome.isSuccess) {
+            logger.info { "reload: classes reloaded successfully" }
+            CallToolResult(content = listOf(TextContent("""{"success":true,"reloaded":true}""")))
+        } else {
+            logger.warn("reload: failed: ${outcome.errorMessage}")
+            CallToolResult(
+                content = listOf(TextContent("Reload failed: ${outcome.errorMessage ?: "unknown error"}")),
+                isError = true
+            )
+        }
+
+        is RecompileResult -> if (outcome.exitCode == 0) {
+            logger.info { "reload: recompiled successfully, no changed classes to reload" }
+            CallToolResult(content = listOf(TextContent(
+                """{"success":true,"reloaded":false,"message":"Recompiled successfully; no changed classes to reload."}"""
+            )))
+        } else {
+            logger.warn("reload: recompilation failed with exit code ${outcome.exitCode}")
+            CallToolResult(
+                content = listOf(TextContent(
+                    "Recompilation failed (exit code ${outcome.exitCode ?: "unknown"}). " +
+                        "Check the build output for compilation errors."
+                )),
+                isError = true
+            )
+        }
+
+        else -> {
+            logger.info { "reload: still in progress after ${timeoutSeconds}s; instructing client to poll 'status'" }
+            CallToolResult(
+                content = listOf(TextContent(
+                    """{"status":"reloading","message":"Reload still in progress after ${timeoutSeconds}s. """ +
+                        """Poll the 'status' tool until 'reloadState' is no longer 'reloading', then check """ +
+                        """'successfulReloads'/'failedReloads' or 'lastError'."}"""
+                ))
+            )
+        }
+    }
 }
 
 private suspend fun handleListWindows(orchestration: StateFlow<OrchestrationHandle?>): CallToolResult {

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -18,8 +18,6 @@ import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.withTimeoutOrNull
@@ -312,9 +310,6 @@ private suspend fun handleReload(
     logger.info { "reload: sending RecompileRequest '${request.messageId}' (timeout ${timeoutSeconds}s)" }
 
     /*
-    The response channel is opened *before* sending the request to avoid missing a result
-    that could otherwise arrive before a cold flow starts collecting.
-
     When the recompilation produces changed classes, the recompiler issues a ReloadClassesRequest
     (whose id we don't know up front) and the application answers with a ReloadClassesResult
     carrying that id. We capture the id of the first ReloadClassesRequest that follows our
@@ -323,24 +318,18 @@ private suspend fun handleReload(
     the RecompileResult for our request instead (sent only once the build, including any reload,
     finished).
      */
-    val channel = handle.asChannel()
-    val outcome = channel.consumeAsFlow().let { flow ->
-        handle.send(request)
-        withTimeoutOrNull(timeoutSeconds.seconds) {
-            var reloadRequestId: OrchestrationMessageId? = null
-            flow.mapNotNull { message ->
-                when (message) {
-                    is ReloadClassesRequest -> {
-                        if (reloadRequestId == null) reloadRequestId = message.messageId
-                        null
-                    }
-                    is ReloadClassesResult ->
-                        message.takeIf { reloadRequestId != null && it.reloadRequestId == reloadRequestId }
-                    is RecompileResult ->
-                        message.takeIf { it.recompileRequestId == request.messageId && reloadRequestId == null }
-                    else -> null
-                }
-            }.firstOrNull()
+    var reloadRequestId: OrchestrationMessageId? = null
+    val outcome = handle.sendAndAwait(request, timeoutSeconds.seconds) { message ->
+        when (message) {
+            is ReloadClassesRequest -> {
+                if (reloadRequestId == null) reloadRequestId = message.messageId
+                null
+            }
+            is ReloadClassesResult ->
+                message.takeIf { reloadRequestId != null && it.reloadRequestId == reloadRequestId }
+            is RecompileResult ->
+                message.takeIf { it.recompileRequestId == request.messageId && reloadRequestId == null }
+            else -> null
         }
     }
 
@@ -583,23 +572,34 @@ private suspend fun resolveWindowId(handle: OrchestrationHandle, args: JsonObjec
 }
 
 /**
- * Sends [request] over orchestration and awaits the matching response of type [R],
- * or returns null if no response arrives within [timeout].
+ * Sends [request] over orchestration, then collects the resulting messages until [match] maps one
+ * to a non-null value, returning it (or null if none arrives within [timeout]).
  *
- * The response channel is opened *before* [request] is sent, eliminating the race
- * where the result could otherwise arrive before a cold flow starts collecting.
- * [consumeAsFlow] auto-closes the channel once the first match is found.
+ * The response channel is opened *before* [request] is sent, eliminating the race where a result
+ * could otherwise arrive before a cold flow starts collecting. [consumeAsFlow] auto-closes the
+ * channel once a terminal value is found.
+ *
+ * [match] is invoked on messages in arrival order, so it may accumulate state across calls
+ * (e.g. capturing an id from one message to match it against a later one).
+ */
+private suspend fun <R> OrchestrationHandle.sendAndAwait(
+    request: OrchestrationMessage,
+    timeout: Duration,
+    match: (OrchestrationMessage) -> R?,
+): R? {
+    val channel = asChannel()
+    return channel.consumeAsFlow().let { flow ->
+        send(request)
+        withTimeoutOrNull(timeout) { flow.mapNotNull(match).firstOrNull() }
+    }
+}
+
+/**
+ * Sends [request] and awaits the matching response of type [R], or null if none arrives within
+ * [timeout]. Thin wrapper over [sendAndAwait] for the common single-response-type case.
  */
 private suspend inline fun <reified R : OrchestrationMessage> OrchestrationHandle.requestResponse(
     request: OrchestrationMessage,
     timeout: Duration = 10.seconds,
     crossinline isResponse: (R) -> Boolean,
-): R? {
-    val channel = asChannel()
-    return channel.consumeAsFlow()
-        .filterIsInstance<R>()
-        .let { flow ->
-            send(request)
-            withTimeoutOrNull(timeout) { flow.first { isResponse(it) } }
-        }
-}
+): R? = sendAndAwait(request, timeout) { message -> (message as? R)?.takeIf(isResponse) }

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -8,6 +8,7 @@ package org.jetbrains.compose.reload.mcp
 
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
@@ -28,6 +29,10 @@ import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.awaitOrThrow
 import org.jetbrains.compose.reload.core.getOrThrow
 import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RecompileRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RecompileResult
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ReloadClassesRequest
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ReloadClassesResult
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ScreenshotResult
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.SemanticTreeResult
@@ -41,6 +46,7 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationClientRole
 import org.jetbrains.compose.reload.orchestration.startOrchestrationServer
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -49,6 +55,19 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class McpServerTest {
+
+    /**
+     * The client created during a test. It keeps an MCP server + client read loop alive
+     * (blocked on a piped-stream read on a shared dispatcher); closing it after every test
+     * frees those threads so the suite does not exhaust the dispatcher's thread pool.
+     */
+    private var client: Client? = null
+
+    @AfterTest
+    fun closeClient() = runBlocking {
+        runCatching { client?.close() }
+        client = null
+    }
 
     private suspend fun CoroutineScope.createMcpClient(orchestration: MutableStateFlow<OrchestrationHandle?>): Client {
         val serverIn = PipedInputStream()
@@ -70,6 +89,7 @@ class McpServerTest {
 
         val client = Client(Implementation(name = "test-client", version = "1.0.0"))
         client.connect(clientTransport)
+        this@McpServerTest.client = client
         return client
     }
 
@@ -835,6 +855,145 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - reload returns error when disconnected`() = runTest(timeout = 10.seconds) {
+        val orchestration = MutableStateFlow<OrchestrationHandle?>(null)
+        val client = createMcpClient(orchestration)
+
+        val result = client.callTool("reload", emptyMap())
+        assertEquals(true, result.isError)
+        val text = (result.content.first() as TextContent).text
+        assertTrue(text.contains("No application is currently connected"))
+    }
+
+    @Test
+    fun `test - reload reports reloaded when classes are reloaded`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            // Simulate a recompiler that requests a class reload, the app reporting success,
+            // then the build result.
+            launch {
+                val request = server.asFlow().filterIsInstance<RecompileRequest>().first()
+                val reloadRequest = ReloadClassesRequest()
+                server.send(reloadRequest)
+                server.send(ReloadClassesResult(reloadRequestId = reloadRequest.messageId, isSuccess = true))
+                server.send(RecompileResult(recompileRequestId = request.messageId, exitCode = 0))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("reload", emptyMap())
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertEquals("""{"success":true,"reloaded":true}""", text)
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - reload reports no changes when recompile succeeds without reload`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            launch {
+                val request = server.asFlow().filterIsInstance<RecompileRequest>().first()
+                server.send(RecompileResult(recompileRequestId = request.messageId, exitCode = 0))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("reload", emptyMap())
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains(""""reloaded":false"""), "unexpected result: $text")
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - reload returns error when reload fails`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            launch {
+                server.asFlow().filterIsInstance<RecompileRequest>().first()
+                val reloadRequest = ReloadClassesRequest()
+                server.send(reloadRequest)
+                server.send(ReloadClassesResult(
+                    reloadRequestId = reloadRequest.messageId,
+                    isSuccess = false,
+                    errorMessage = "Incompatible change",
+                ))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("reload", emptyMap())
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Incompatible change"), "unexpected error message: $text")
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - reload returns error when recompilation fails`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            launch {
+                val request = server.asFlow().filterIsInstance<RecompileRequest>().first()
+                server.send(RecompileResult(recompileRequestId = request.messageId, exitCode = 1))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("reload", emptyMap())
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Recompilation failed"), "unexpected error message: $text")
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `test - reload reports still reloading and asks to poll on timeout`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        try {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            // No recompiler responds, so the call must hit the timeout.
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("reload", mapOf("timeout_seconds" to 1))
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains(""""status":"reloading""""), "unexpected result: $text")
+            assertTrue(text.contains("status"), "expected a hint to poll 'status': $text")
         } finally {
             server.close()
         }

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -124,7 +124,7 @@ class McpServerTest {
     @Test
     fun `test - status returns connected when app is running`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -134,8 +134,6 @@ class McpServerTest {
             val result = client.callTool("status", emptyMap())
             val text = (result.content.first() as TextContent).text
             assertEquals("""{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""", text)
-        } finally {
-            server.close()
         }
     }
 
@@ -153,7 +151,7 @@ class McpServerTest {
     @Test
     fun `test - take_screenshot returns image when connected`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -174,8 +172,6 @@ class McpServerTest {
             assertNotEquals(true, result.isError)
             val imageContent = result.content.first()
             assertNotNull(imageContent)
-        } finally {
-            server.close()
         }
     }
 
@@ -193,7 +189,7 @@ class McpServerTest {
     @Test
     fun `test - get_semantic_tree returns tree when connected`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -212,8 +208,6 @@ class McpServerTest {
             assertNotEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertEquals(someJson, text)
-        } finally {
-            server.close()
         }
     }
 
@@ -231,7 +225,7 @@ class McpServerTest {
     @Test
     fun `test - click succeeds and forwards nodeId`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -251,15 +245,13 @@ class McpServerTest {
             assertNotEquals(true, result.isError)
             assertEquals(7, receivedNodeId)
             assertEquals(UIAction.Click, receivedAction)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - click returns error when app reports failure`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -281,15 +273,13 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Node 7 not found"))
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - long_click succeeds and dispatches LongClick action`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -306,15 +296,13 @@ class McpServerTest {
             val result = client.callTool("long_click", mapOf("nodeId" to 3))
             assertNotEquals(true, result.isError)
             assertEquals(UIAction.LongClick, receivedAction)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - type_text forwards text to app`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -334,15 +322,13 @@ class McpServerTest {
             )
             assertNotEquals(true, result.isError)
             assertEquals(UIAction.SetText("hello world"), receivedAction)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - scroll forwards deltas to app`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -362,15 +348,13 @@ class McpServerTest {
             )
             assertNotEquals(true, result.isError)
             assertEquals(UIAction.ScrollBy(10f, -20.5f), receivedAction)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - scroll_to_index forwards index to app`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -390,8 +374,6 @@ class McpServerTest {
             )
             assertNotEquals(true, result.isError)
             assertEquals(UIAction.ScrollToIndex(42), receivedAction)
-        } finally {
-            server.close()
         }
     }
 
@@ -423,7 +405,7 @@ class McpServerTest {
     @Test
     fun `test - status reflects orchestration state after reconnect`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient1 = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -447,15 +429,13 @@ class McpServerTest {
                 """{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""",
                 text,
             )
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - status shows reloading when ReloadState is Reloading`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -468,15 +448,13 @@ class McpServerTest {
                 """{"connected":true,"reloadState":"reloading","lastError":null,"successfulReloads":0,"failedReloads":0}""",
                 text,
             )
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - status reflects successful reload count`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -490,8 +468,6 @@ class McpServerTest {
                 """{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":1,"failedReloads":0}""",
                 text,
             )
-        } finally {
-            server.close()
         }
     }
 
@@ -533,7 +509,7 @@ class McpServerTest {
     @Test
     fun `test - list_windows returns empty array when no windows are registered`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -543,15 +519,13 @@ class McpServerTest {
             val result = client.callTool("list_windows", emptyMap())
             val text = (result.content.first() as TextContent).text
             assertEquals("[]", text)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - list_windows returns registered windows in insertion order`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -571,15 +545,13 @@ class McpServerTest {
                     """{"id":"w-2","title":"Settings","x":30,"y":40,"width":300,"height":400}]""",
                 text,
             )
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - list_windows serializes null title as JSON null`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -597,15 +569,13 @@ class McpServerTest {
                 """[{"id":"w-1","title":null,"x":0,"y":0,"width":100,"height":100}]""",
                 text,
             )
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - list_windows reflects title changes`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -637,15 +607,13 @@ class McpServerTest {
                 }
                 Thread.sleep(10)
             }
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - take_screenshot forwards explicit window_id`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -674,15 +642,13 @@ class McpServerTest {
             val result = client.callTool("take_screenshot", mapOf("window_id" to "w-2"))
             assertNotEquals(true, result.isError)
             assertEquals(WindowId("w-2"), receivedWindowId)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - take_screenshot defaults to first registered window`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -711,15 +677,13 @@ class McpServerTest {
             val result = client.callTool("take_screenshot", emptyMap())
             assertNotEquals(true, result.isError)
             assertEquals(WindowId("w-1"), receivedWindowId)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - take_screenshot returns error for unknown window_id`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -737,15 +701,13 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - get_semantic_tree forwards explicit window_id`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -770,15 +732,13 @@ class McpServerTest {
             val result = client.callTool("get_semantic_tree", mapOf("window_id" to "w-2"))
             assertNotEquals(true, result.isError)
             assertEquals(WindowId("w-2"), receivedWindowId)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - get_semantic_tree returns error for unknown window_id`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -796,15 +756,13 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - click forwards explicit window_id`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -829,15 +787,13 @@ class McpServerTest {
             val result = client.callTool("click", mapOf("nodeId" to 7, "window_id" to "w-2"))
             assertNotEquals(true, result.isError)
             assertEquals(WindowId("w-2"), receivedWindowId)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - click returns error for unknown window_id`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -855,8 +811,6 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
-        } finally {
-            server.close()
         }
     }
 
@@ -874,7 +828,7 @@ class McpServerTest {
     @Test
     fun `test - reload reports reloaded when classes are reloaded`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -895,15 +849,13 @@ class McpServerTest {
             assertNotEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertEquals("""{"success":true,"reloaded":true}""", text)
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - reload reports no changes when recompile succeeds without reload`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -919,15 +871,13 @@ class McpServerTest {
             assertNotEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains(""""reloaded":false"""), "unexpected result: $text")
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - reload returns error when reload fails`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -949,15 +899,13 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Incompatible change"), "unexpected error message: $text")
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - reload returns error when recompilation fails`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -973,15 +921,13 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Recompilation failed"), "unexpected error message: $text")
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - reload reports still reloading and asks to poll on timeout`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -994,15 +940,13 @@ class McpServerTest {
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains(""""status":"reloading""""), "unexpected result: $text")
             assertTrue(text.contains("status"), "expected a hint to poll 'status': $text")
-        } finally {
-            server.close()
         }
     }
 
     @Test
     fun `test - status shows failed when ReloadState is Failed`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
-        try {
+        server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
@@ -1016,8 +960,6 @@ class McpServerTest {
                 """{"connected":true,"reloadState":"failed","lastError":"Compilation error","successfulReloads":0,"failedReloads":1}""",
                 text,
             )
-        } finally {
-            server.close()
         }
     }
 }


### PR DESCRIPTION
Adds a `reload` tool to the MCP server so an AI agent can apply source
edits to a running Compose app without restarting it.