### PR TITLE
[mcpserver] Add get_ui_error tool

### DIFF
--- a/hot-reload-devtools-api/api/hot-reload-devtools-api.api
+++ b/hot-reload-devtools-api/api/hot-reload-devtools-api.api
@@ -180,6 +180,32 @@ public final class org/jetbrains/compose/devtools/api/ReloadState$Reloading : or
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/jetbrains/compose/devtools/api/UIErrorState : org/jetbrains/compose/reload/orchestration/OrchestrationState {
+	public static final field $stable I
+	public static final field Key Lorg/jetbrains/compose/devtools/api/UIErrorState$Key;
+	public fun <init> (Ljava/util/Map;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrors ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/compose/devtools/api/UIErrorState$Key : org/jetbrains/compose/reload/orchestration/OrchestrationStateKey {
+	public fun getDefault ()Lorg/jetbrains/compose/devtools/api/UIErrorState;
+	public synthetic fun getDefault ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationState;
+	public fun getId ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationStateId;
+}
+
+public final class org/jetbrains/compose/devtools/api/UIErrorState$UIError {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getStacktrace ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/jetbrains/compose/devtools/api/VirtualTimeState$Key : org/jetbrains/compose/reload/orchestration/OrchestrationStateKey {
 	public fun getDefault ()Lorg/jetbrains/compose/devtools/api/VirtualTimeState;
 	public synthetic fun getDefault ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationState;

--- a/hot-reload-devtools-api/src/main/kotlin/org/jetbrains/compose/devtools/api/UIErrorState.kt
+++ b/hot-reload-devtools-api/src/main/kotlin/org/jetbrains/compose/devtools/api/UIErrorState.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024-2026 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.devtools.api
+
+import org.jetbrains.compose.devtools.api.UIErrorState.UIError
+import org.jetbrains.compose.reload.ExperimentalHotReloadApi
+import org.jetbrains.compose.reload.core.Try
+import org.jetbrains.compose.reload.core.Type
+import org.jetbrains.compose.reload.core.WindowId
+import org.jetbrains.compose.reload.core.decode
+import org.jetbrains.compose.reload.core.encodeByteArray
+import org.jetbrains.compose.reload.core.readFields
+import org.jetbrains.compose.reload.core.readStringList
+import org.jetbrains.compose.reload.core.tryDecode
+import org.jetbrains.compose.reload.core.type
+import org.jetbrains.compose.reload.core.writeFields
+import org.jetbrains.compose.reload.core.writeStringList
+import org.jetbrains.compose.reload.orchestration.OrchestrationState
+import org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
+import org.jetbrains.compose.reload.orchestration.OrchestrationStateId
+import org.jetbrains.compose.reload.orchestration.OrchestrationStateKey
+import org.jetbrains.compose.reload.orchestration.stateId
+
+/**
+ * Runtime UI exceptions currently shown by the application, keyed by [WindowId].
+ *
+ * An entry is present while the composition of that window is failing (reported by the runtime when
+ * invoking the development entry point throws) and is removed once the window renders successfully
+ * again. This differs from a reload failure (see [ReloadState.Failed]): a [UIError] is an exception
+ * thrown while building the UI itself.
+ */
+@ExperimentalHotReloadApi
+public class UIErrorState(
+    public val errors: Map<WindowId, UIError>
+) : OrchestrationState {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is UIErrorState) return false
+        if (errors != other.errors) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return errors.hashCode()
+    }
+
+    override fun toString(): String {
+        return "UIErrorState($errors)"
+    }
+
+    public class UIError(
+        public val message: String?,
+        public val stacktrace: List<String>,
+    ) {
+        private val hashCode: Int = run {
+            var result = message?.hashCode() ?: 0
+            result = 31 * result + stacktrace.hashCode()
+            result
+        }
+
+        override fun hashCode(): Int {
+            return hashCode
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is UIError) return false
+            if (other.hashCode() != hashCode) return false
+            if (this.message != other.message) return false
+            if (this.stacktrace != other.stacktrace) return false
+            return true
+        }
+
+        override fun toString(): String {
+            return "UIError(message=$message)"
+        }
+    }
+
+    public companion object Key : OrchestrationStateKey<UIErrorState>() {
+        override val id: OrchestrationStateId<UIErrorState> = stateId()
+        override val default: UIErrorState = UIErrorState(emptyMap())
+    }
+}
+
+internal class UIErrorStateEncoder : OrchestrationStateEncoder<UIErrorState> {
+    override val type: Type<UIErrorState> = type()
+
+    override fun encode(state: UIErrorState): ByteArray = encodeByteArray {
+        writeInt(state.errors.size)
+        state.errors.forEach { (windowId, error) ->
+            writeFields(
+                "windowId" to windowId.value.encodeToByteArray(),
+                "message" to error.message?.encodeToByteArray(),
+                "stacktrace" to encodeByteArray { writeStringList(error.stacktrace) },
+            )
+        }
+    }
+
+    override fun decode(data: ByteArray): Try<UIErrorState> = data.tryDecode {
+        val count = readInt()
+        val errors = buildMap {
+            repeat(count) {
+                val fields = readFields()
+                this += WindowId(fields["windowId"]?.decodeToString() ?: error("Missing 'windowId'")) to UIError(
+                    // Missing or absent message decodes to null.
+                    message = fields["message"]?.decodeToString(),
+                    stacktrace = fields["stacktrace"]?.decode { readStringList() } ?: emptyList(),
+                )
+            }
+        }
+        UIErrorState(errors)
+    }
+}

--- a/hot-reload-devtools-api/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
+++ b/hot-reload-devtools-api/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
@@ -6,3 +6,4 @@ org.jetbrains.compose.devtools.api.ReloadStateEncoder
 org.jetbrains.compose.devtools.api.ReloadCountStateEncoder
 org.jetbrains.compose.devtools.api.WindowsStateEncoder
 org.jetbrains.compose.devtools.api.VirtualTimeStateEncoder
+org.jetbrains.compose.devtools.api.UIErrorStateEncoder

--- a/hot-reload-devtools-api/src/test/kotlin/UIErrorStateTest.kt
+++ b/hot-reload-devtools-api/src/test/kotlin/UIErrorStateTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+import org.jetbrains.compose.devtools.api.UIErrorState
+import org.jetbrains.compose.reload.core.WindowId
+import org.jetbrains.compose.reload.core.getOrThrow
+import org.jetbrains.compose.reload.orchestration.encoderOfOrThrow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UIErrorStateTest {
+    private val encoder = encoderOfOrThrow(UIErrorState)
+
+    @Test
+    fun `test - encode decode`() {
+        val empty = UIErrorState(emptyMap())
+        assertEquals(empty, encoder.decode(encoder.encode(empty)).getOrThrow())
+
+        val nonEmpty = UIErrorState(
+            mapOf(
+                WindowId.create() to UIErrorState.UIError(
+                    message = "boom",
+                    stacktrace = listOf("a.b.C.foo(C.kt:1)", "a.b.C.bar(C.kt:2)"),
+                ),
+                WindowId.create() to UIErrorState.UIError(
+                    message = null,
+                    stacktrace = emptyList(),
+                ),
+            )
+        )
+
+        assertEquals(nonEmpty, encoder.decode(encoder.encode(nonEmpty)).getOrThrow())
+    }
+}

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/errorOverlay/DevToolingErrorOverlay.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/errorOverlay/DevToolingErrorOverlay.kt
@@ -172,7 +172,7 @@ private fun DevToolingErrorOverlay(
                 }
 
                 DtConsole(
-                    logs = error.stacktrace.map { it.toString() },
+                    logs = error.stacktrace,
                     modifier = Modifier.fillMaxSize(),
                     scrollToBottom = false,
                 )

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/ErrorUIState.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/ErrorUIState.kt
@@ -8,15 +8,13 @@ package org.jetbrains.compose.devtools.states
 import io.sellmair.evas.State
 import io.sellmair.evas.launchState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.launch
-import org.jetbrains.compose.devtools.orchestration
-import org.jetbrains.compose.devtools.sendAsync
+import org.jetbrains.compose.devtools.api.UIErrorState
+import org.jetbrains.compose.devtools.asFlow
 import org.jetbrains.compose.reload.core.WindowId
-import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
-import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
-import org.jetbrains.compose.reload.orchestration.asFlow
 
+/**
+ * Devtools-side mirror of the shared [UIErrorState] orchestration state.
+ */
 data class ErrorUIState(val errors: Map<WindowId, UIErrorDescription>) : State {
     companion object Key : State.Key<ErrorUIState> {
         override val default: ErrorUIState = ErrorUIState(emptyMap())
@@ -26,41 +24,19 @@ data class ErrorUIState(val errors: Map<WindowId, UIErrorDescription>) : State {
 data class UIErrorDescription(
     val title: String,
     val message: String?,
-    val stacktrace: List<StackTraceElement>,
-    val recovery: (() -> Unit)? = null
+    val stacktrace: List<String>,
 )
 
-fun CoroutineScope.launchErrorUIState(
-    orchestration: OrchestrationHandle = org.jetbrains.compose.devtools.orchestration,
-) = launchState(ErrorUIState) {
-    val errors = mutableMapOf<WindowId, UIErrorDescription>()
-
-    suspend fun update() {
-        ErrorUIState(errors = errors.toMap()).emit()
-    }
-
-    launch {
-        orchestration.asFlow().filterIsInstance<OrchestrationMessage.UIException>().collect { message ->
-            val windowId = message.windowId ?: return@collect
-            errors[windowId] = message.toDescription()
-            update()
-        }
-    }
-
-    launch {
-        orchestration.asFlow().filterIsInstance<OrchestrationMessage.UIRendered>().collect { message ->
-            val windowId = message.windowId ?: return@collect
-            errors.remove(windowId)
-            update()
-        }
+fun CoroutineScope.launchErrorUIState() = launchState(ErrorUIState) {
+    UIErrorState.asFlow().collect { state ->
+        ErrorUIState(errors = state.errors.mapValues { (_, error) -> error.toDescription() }).emit()
     }
 }
 
-private fun OrchestrationMessage.UIException.toDescription(): UIErrorDescription {
+private fun UIErrorState.UIError.toDescription(): UIErrorDescription {
     return UIErrorDescription(
         title = "UI Exception",
         message = message,
         stacktrace = stacktrace,
-        recovery = { OrchestrationMessage.RetryFailedCompositionRequest().sendAsync() }
     )
 }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/NotificationsUIState.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/NotificationsUIState.kt
@@ -160,7 +160,7 @@ private fun UIErrorDescription.toNotification(): UINotification = UINotification
     title = title,
     message = message.orEmpty(),
     isDisposableFromUI = false,
-    details = stacktrace.map { it.toString() }
+    details = stacktrace
 )
 
 

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -305,6 +305,62 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
     server.createSession(transport)
 }
 
+/** Standard message returned by every tool when no application is connected. */
+private const val NOT_CONNECTED_MESSAGE =
+    "No application is currently connected. Use the 'status' tool to check availability."
+
+/** Builds an error [CallToolResult] carrying [message]. */
+private fun errorResult(message: String): CallToolResult =
+    CallToolResult(content = listOf(TextContent(message)), isError = true)
+
+/** Builds a success [CallToolResult] carrying [text]. */
+private fun textResult(text: String): CallToolResult =
+    CallToolResult(content = listOf(TextContent(text)))
+
+/**
+ * Runs [body] with the currently connected [OrchestrationHandle], or returns the standard
+ * "not connected" error. [toolName] is used only for logging.
+ */
+private suspend fun withConnection(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    toolName: String,
+    body: suspend (OrchestrationHandle) -> CallToolResult,
+): CallToolResult {
+    val handle = orchestration.value ?: run {
+        logger.info { "$toolName: no application connected" }
+        return errorResult(NOT_CONNECTED_MESSAGE)
+    }
+    return body(handle)
+}
+
+/**
+ * Resolves the target window for [args] and runs [body] with it, or returns a "window not found"
+ * error. Use within a [withConnection] body when other arguments must be validated alongside the
+ * window; otherwise prefer [withWindow].
+ */
+private suspend fun OrchestrationHandle.withResolvedWindow(
+    args: JsonObject?,
+    body: suspend (WindowId) -> CallToolResult,
+): CallToolResult = try {
+    body(resolveWindowId(this, args))
+} catch (e: WindowIdNotFoundException) {
+    errorResult(e.message ?: "Invalid window_id")
+}
+
+/**
+ * Runs [body] with the connected handle and the resolved target window — the common
+ * "connected + single window" case. Returns the standard not-connected / window-not-found error
+ * otherwise.
+ */
+private suspend fun withWindow(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    toolName: String,
+    args: JsonObject?,
+    body: suspend (OrchestrationHandle, WindowId) -> CallToolResult,
+): CallToolResult = withConnection(orchestration, toolName) { handle ->
+    handle.withResolvedWindow(args) { windowId -> body(handle, windowId) }
+}
+
 private suspend fun handleStatus(
     orchestration: StateFlow<OrchestrationHandle?>,
     toolRequest: CallToolRequest,
@@ -312,9 +368,7 @@ private suspend fun handleStatus(
     val handle = orchestration.value
     if (handle == null) {
         logger.debug { "status: not connected" }
-        return CallToolResult(
-            content = listOf(TextContent(buildJsonObject { put("connected", false) }.toString()))
-        )
+        return textResult(buildJsonObject { put("connected", false) }.toString())
     }
     val state = handle.states.get(ReloadState).value
     val count = handle.states.get(ReloadCountState).value
@@ -324,8 +378,7 @@ private suspend fun handleStatus(
         is ReloadState.Failed -> "failed"
     }
     logger.debug { "status: connected reloadState=$reloadStateStr" }
-    return CallToolResult(
-        content = listOf(TextContent(buildJsonObject {
+    return textResult(buildJsonObject {
             put("connected", true)
             put("reloadState", reloadStateStr)
             put("lastError", (state as? ReloadState.Failed)?.reason)
@@ -346,8 +399,7 @@ private suspend fun handleStatus(
             if (uiErrorWindows.isNotEmpty()) {
                 put("uiErrorWindows", buildJsonArray { uiErrorWindows.forEach { add(it.value) } })
             }
-        }.toString()))
-    )
+        }.toString())
 }
 
 /**
@@ -368,13 +420,7 @@ private const val DEFAULT_RELOAD_TIMEOUT_SECONDS = 60
 private suspend fun handleReload(
     orchestration: StateFlow<OrchestrationHandle?>,
     toolRequest: CallToolRequest,
-): CallToolResult {
-    val handle = orchestration.value
-        ?: return CallToolResult(
-            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
-            isError = true
-        ).also { logger.info { "reload: no application connected" } }
-
+): CallToolResult = withConnection(orchestration, "reload") { handle ->
     val timeoutSeconds = (toolRequest.arguments?.get("timeout_seconds")?.jsonPrimitive?.intOrNull
         ?: DEFAULT_RELOAD_TIMEOUT_SECONDS).coerceAtLeast(1)
 
@@ -405,87 +451,60 @@ private suspend fun handleReload(
         }
     }
 
-    return when (outcome) {
+    when (outcome) {
         is ReloadClassesResult -> if (outcome.isSuccess) {
             logger.info { "reload: classes reloaded successfully" }
-            CallToolResult(content = listOf(TextContent("""{"success":true,"reloaded":true}""")))
+            textResult("""{"success":true,"reloaded":true}""")
         } else {
             logger.warn("reload: failed: ${outcome.errorMessage}")
-            CallToolResult(
-                content = listOf(TextContent("Reload failed: ${outcome.errorMessage ?: "unknown error"}")),
-                isError = true
-            )
+            errorResult("Reload failed: ${outcome.errorMessage ?: "unknown error"}")
         }
 
         is RecompileResult -> if (outcome.exitCode == 0) {
             logger.info { "reload: recompiled successfully, no changed classes to reload" }
-            CallToolResult(content = listOf(TextContent(
-                """{"success":true,"reloaded":false,"message":"Recompiled successfully; no changed classes to reload."}"""
-            )))
+            textResult("""{"success":true,"reloaded":false,"message":"Recompiled successfully; no changed classes to reload."}""")
         } else {
             logger.warn("reload: recompilation failed with exit code ${outcome.exitCode}")
-            CallToolResult(
-                content = listOf(TextContent(
-                    "Recompilation failed (exit code ${outcome.exitCode ?: "unknown"}). " +
-                        "Check the build output for compilation errors."
-                )),
-                isError = true
+            errorResult(
+                "Recompilation failed (exit code ${outcome.exitCode ?: "unknown"}). " +
+                    "Check the build output for compilation errors."
             )
         }
 
         else -> {
             logger.info { "reload: still in progress after ${timeoutSeconds}s; instructing client to poll 'status'" }
-            CallToolResult(
-                content = listOf(TextContent(
-                    """{"status":"reloading","message":"Reload still in progress after ${timeoutSeconds}s. """ +
-                        """Poll the 'status' tool until 'reloadState' is no longer 'reloading', then check """ +
-                        """'successfulReloads'/'failedReloads' or 'lastError'."}"""
-                ))
+            textResult(
+                """{"status":"reloading","message":"Reload still in progress after ${timeoutSeconds}s. """ +
+                    """Poll the 'status' tool until 'reloadState' is no longer 'reloading', then check """ +
+                    """'successfulReloads'/'failedReloads' or 'lastError'."}"""
             )
         }
     }
 }
 
-private suspend fun handleListWindows(orchestration: StateFlow<OrchestrationHandle?>): CallToolResult {
-    val handle = orchestration.value
-        ?: return CallToolResult(
-            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
-            isError = true
-        ).also { logger.info { "list_windows: no application connected" } }
-
-    val windows = handle.states.get(WindowsState).value.windows
-    logger.debug { "list_windows: ${windows.size} window(s)" }
-    val json = buildJsonArray {
-        windows.forEach { (id, state) ->
-            addJsonObject {
-                put("id", id.value)
-                put("title", state.title)
-                put("x", state.x)
-                put("y", state.y)
-                put("width", state.width)
-                put("height", state.height)
+private suspend fun handleListWindows(orchestration: StateFlow<OrchestrationHandle?>): CallToolResult =
+    withConnection(orchestration, "list_windows") { handle ->
+        val windows = handle.states.get(WindowsState).value.windows
+        logger.debug { "list_windows: ${windows.size} window(s)" }
+        val json = buildJsonArray {
+            windows.forEach { (id, state) ->
+                addJsonObject {
+                    put("id", id.value)
+                    put("title", state.title)
+                    put("x", state.x)
+                    put("y", state.y)
+                    put("width", state.width)
+                    put("height", state.height)
+                }
             }
         }
+        textResult(json.toString())
     }
-    return CallToolResult(content = listOf(TextContent(json.toString())))
-}
 
 private suspend fun handleGetUIError(
     orchestration: StateFlow<OrchestrationHandle?>,
     toolRequest: CallToolRequest,
-): CallToolResult {
-    val handle = orchestration.value
-        ?: return CallToolResult(
-            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
-            isError = true
-        ).also { logger.info { "get_ui_error: no application connected" } }
-
-    val resolvedId = try {
-        resolveWindowId(handle, toolRequest.arguments)
-    } catch (e: WindowIdNotFoundException) {
-        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
-    }
-
+): CallToolResult = withWindow(orchestration, "get_ui_error", toolRequest.arguments) { handle, resolvedId ->
     val error = handle.states.get(UIErrorState).value.errors[resolvedId]
     val maxDetailLines = (toolRequest.arguments?.get("max_error_detail_lines")?.jsonPrimitive?.intOrNull
         ?: DEFAULT_MAX_ERROR_DETAIL_LINES).coerceAtLeast(0)
@@ -505,101 +524,60 @@ private suspend fun handleGetUIError(
             }
         }
     }
-    return CallToolResult(content = listOf(TextContent(json.toString())))
+    textResult(json.toString())
 }
 
 private suspend fun handleTakeScreenshot(
     orchestration: StateFlow<OrchestrationHandle?>,
     request: CallToolRequest,
-): CallToolResult {
-    val handle = orchestration.value
-        ?: return CallToolResult(
-            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
-            isError = true
-        ).also { logger.info { "take_screenshot: no application connected" } }
-
-    val resolvedId = try {
-        resolveWindowId(handle, request.arguments)
-    } catch (e: WindowIdNotFoundException) {
-        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
-    }
-
-    return try {
-        val request = ScreenshotRequest(windowId = resolvedId)
-        logger.info { "take_screenshot: sending request '${request.messageId}'" }
-        val screenshot = handle.requestResponse<ScreenshotResult>(request) {
-            it.screenshotRequestId == request.messageId
+): CallToolResult = withWindow(orchestration, "take_screenshot", request.arguments) { handle, resolvedId ->
+    try {
+        val screenshotRequest = ScreenshotRequest(windowId = resolvedId)
+        logger.info { "take_screenshot: sending request '${screenshotRequest.messageId}'" }
+        val screenshot = handle.requestResponse<ScreenshotResult>(screenshotRequest) {
+            it.screenshotRequestId == screenshotRequest.messageId
         }
-
-        if (screenshot == null) {
-            logger.warn("take_screenshot: timed out waiting for response")
-            return CallToolResult(
-                content = listOf(TextContent("Screenshot timed out: no response from application")),
-                isError = true
-            )
+        when {
+            screenshot == null -> {
+                logger.warn("take_screenshot: timed out waiting for response")
+                errorResult("Screenshot timed out: no response from application")
+            }
+            !screenshot.isSuccess -> {
+                logger.warn("take_screenshot: failed: ${screenshot.errorMessage}")
+                errorResult("Screenshot failed: ${screenshot.errorMessage ?: "unknown error"}")
+            }
+            else -> {
+                logger.debug { "take_screenshot: received ${screenshot.data.size} bytes (${screenshot.format})" }
+                val base64 = Base64.getEncoder().encodeToString(screenshot.data)
+                CallToolResult(content = listOf(ImageContent(data = base64, mimeType = "image/${screenshot.format}")))
+            }
         }
-
-        if (!screenshot.isSuccess) {
-            logger.warn("take_screenshot: failed: ${screenshot.errorMessage}")
-            return CallToolResult(
-                content = listOf(TextContent("Screenshot failed: ${screenshot.errorMessage ?: "unknown error"}")),
-                isError = true
-            )
-        }
-
-        logger.debug { "take_screenshot: received ${screenshot.data.size} bytes (${screenshot.format})" }
-        val base64 = Base64.getEncoder().encodeToString(screenshot.data)
-        CallToolResult(
-            content = listOf(ImageContent(data = base64, mimeType = "image/${screenshot.format}"))
-        )
     } catch (e: Exception) {
         logger.warn("take_screenshot: exception: ${e.message}")
-        CallToolResult(
-            content = listOf(TextContent("Screenshot failed: ${e.message}")),
-            isError = true
-        )
+        errorResult("Screenshot failed: ${e.message}")
     }
 }
 
 private suspend fun handleGetSemanticTree(
     orchestration: StateFlow<OrchestrationHandle?>,
     request: CallToolRequest,
-): CallToolResult {
-    val handle = orchestration.value
-        ?: return CallToolResult(
-            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
-            isError = true
-        ).also { logger.info { "get_semantic_tree: no application connected" } }
-
-    val resolvedId = try {
-        resolveWindowId(handle, request.arguments)
-    } catch (e: WindowIdNotFoundException) {
-        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
-    }
-
-    return try {
-        val request = SemanticTreeRequest(windowId = resolvedId)
-        logger.info { "get_semantic_tree: sending request '${request.messageId}'" }
-        val semanticTree = handle.requestResponse<SemanticTreeResult>(request) {
-            it.semanticTreeRequestId == request.messageId
+): CallToolResult = withWindow(orchestration, "get_semantic_tree", request.arguments) { handle, resolvedId ->
+    try {
+        val treeRequest = SemanticTreeRequest(windowId = resolvedId)
+        logger.info { "get_semantic_tree: sending request '${treeRequest.messageId}'" }
+        val semanticTree = handle.requestResponse<SemanticTreeResult>(treeRequest) {
+            it.semanticTreeRequestId == treeRequest.messageId
         }
-
         if (semanticTree == null) {
             logger.warn("get_semantic_tree: timed out waiting for response")
-            return CallToolResult(
-                content = listOf(TextContent("Semantic tree request timed out: no response from application")),
-                isError = true
-            )
+            errorResult("Semantic tree request timed out: no response from application")
+        } else {
+            logger.debug { "get_semantic_tree: received ${semanticTree.tree.length} chars" }
+            textResult(semanticTree.tree)
         }
-
-        logger.debug { "get_semantic_tree: received ${semanticTree.tree.length} chars" }
-        CallToolResult(content = listOf(TextContent(semanticTree.tree)))
     } catch (e: Exception) {
         logger.warn("get_semantic_tree: exception: ${e.message}")
-        CallToolResult(
-            content = listOf(TextContent("Semantic tree request failed: ${e.message}")),
-            isError = true
-        )
+        errorResult("Semantic tree request failed: ${e.message}")
     }
 }
 
@@ -607,119 +585,76 @@ private suspend fun handleUIAction(
     orchestration: StateFlow<OrchestrationHandle?>,
     request: CallToolRequest,
     actionFactory: (JsonObject?) -> UIAction,
-): CallToolResult {
-    val handle = orchestration.value
-        ?: return CallToolResult(
-            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
-            isError = true
-        ).also { logger.info { "${request.name}: no application connected" } }
-
+): CallToolResult = withConnection(orchestration, request.name) { handle ->
     val args = request.arguments
     val nodeId = args?.get("nodeId")?.jsonPrimitive?.intOrNull
-        ?: return CallToolResult(
-            content = listOf(TextContent("Missing required parameter 'nodeId' (integer)")),
-            isError = true
-        )
+        ?: return@withConnection errorResult("Missing required parameter 'nodeId' (integer)")
 
     val action = try {
         actionFactory(args)
     } catch (e: Exception) {
-        return CallToolResult(
-            content = listOf(TextContent(e.message ?: "Invalid arguments")),
-            isError = true
-        )
+        return@withConnection errorResult(e.message ?: "Invalid arguments")
     }
 
-    val resolvedId = try {
-        resolveWindowId(handle, args)
-    } catch (e: WindowIdNotFoundException) {
-        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
-    }
-
-    return try {
-        val uiActionRequest = UIActionRequest(nodeId = nodeId, action = action, windowId = resolvedId)
-        logger.info { "${request.name}: sending request '${uiActionRequest.messageId}' nodeId=$nodeId action=$action" }
-        val actionResult = handle.requestResponse<UIActionResult>(uiActionRequest) {
-            it.uiActionRequestId == uiActionRequest.messageId
+    handle.withResolvedWindow(args) { resolvedId ->
+        try {
+            val uiActionRequest = UIActionRequest(nodeId = nodeId, action = action, windowId = resolvedId)
+            logger.info { "${request.name}: sending request '${uiActionRequest.messageId}' nodeId=$nodeId action=$action" }
+            val actionResult = handle.requestResponse<UIActionResult>(uiActionRequest) {
+                it.uiActionRequestId == uiActionRequest.messageId
+            }
+            when {
+                actionResult == null -> {
+                    logger.warn("${request.name}: timed out waiting for response")
+                    errorResult("UI action timed out: no response from application")
+                }
+                !actionResult.isSuccess -> {
+                    logger.warn("${request.name}: failed: ${actionResult.errorMessage}")
+                    errorResult("UI action failed: ${actionResult.errorMessage ?: "unknown error"}")
+                }
+                else -> {
+                    logger.debug { "${request.name}: succeeded" }
+                    textResult("""{"success": true}""")
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn("${request.name}: exception: ${e.message}")
+            errorResult("UI action failed: ${e.message}")
         }
-
-        if (actionResult == null) {
-            logger.warn("${request.name}: timed out waiting for response")
-            return CallToolResult(
-                content = listOf(TextContent("UI action timed out: no response from application")),
-                isError = true
-            )
-        }
-
-        if (!actionResult.isSuccess) {
-            logger.warn("${request.name}: failed: ${actionResult.errorMessage}")
-            return CallToolResult(
-                content = listOf(TextContent("UI action failed: ${actionResult.errorMessage ?: "unknown error"}")),
-                isError = true
-            )
-        }
-
-        logger.debug { "${request.name}: succeeded" }
-        CallToolResult(content = listOf(TextContent("""{"success": true}""")))
-    } catch (e: Exception) {
-        logger.warn("${request.name}: exception: ${e.message}")
-        CallToolResult(
-            content = listOf(TextContent("UI action failed: ${e.message}")),
-            isError = true
-        )
     }
 }
 
 private suspend fun handleResizeWindow(
     orchestration: StateFlow<OrchestrationHandle?>,
     request: CallToolRequest,
-): CallToolResult {
-    val handle = orchestration.value
-        ?: return CallToolResult(
-            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
-            isError = true
-        ).also { logger.info { "resize_window: no application connected" } }
-
+): CallToolResult = withConnection(orchestration, "resize_window") { handle ->
     val args = request.arguments
     val width = args?.get("width")?.jsonPrimitive?.intOrNull
-        ?: return CallToolResult(
-            content = listOf(TextContent("Missing required parameter 'width' (integer)")),
-            isError = true
-        )
+        ?: return@withConnection errorResult("Missing required parameter 'width' (integer)")
     val height = args["height"]?.jsonPrimitive?.intOrNull
-        ?: return CallToolResult(
-            content = listOf(TextContent("Missing required parameter 'height' (integer)")),
-            isError = true
-        )
+        ?: return@withConnection errorResult("Missing required parameter 'height' (integer)")
 
-    val result = try {
-        val resolvedId = resolveWindowId(handle, args)
-        val resizeRequest = WindowResizeRequest(width = width, height = height, windowId = resolvedId)
-        logger.info { "resize_window: sending request '${resizeRequest.messageId}' ${width}x${height}" }
-        val response = handle.requestResponse<WindowResizeResult>(resizeRequest) {
-            it.windowResizeRequestId == resizeRequest.messageId
+    val result = handle.withResolvedWindow(args) { resolvedId ->
+        try {
+            val resizeRequest = WindowResizeRequest(width = width, height = height, windowId = resolvedId)
+            logger.info { "resize_window: sending request '${resizeRequest.messageId}' ${width}x${height}" }
+            val response = handle.requestResponse<WindowResizeResult>(resizeRequest) {
+                it.windowResizeRequestId == resizeRequest.messageId
+            }
+            when {
+                response == null -> errorResult("Window resize timed out: no response from application")
+                !response.isSuccess -> errorResult("Window resize failed: ${response.errorMessage ?: "unknown error"}")
+                else -> textResult("""{"success": true}""")
+            }
+        } catch (e: Exception) {
+            errorResult("Window resize failed: ${e.message}")
         }
-        when {
-            response == null -> CallToolResult(
-                content = listOf(TextContent("Window resize timed out: no response from application")),
-                isError = true
-            )
-            !response.isSuccess -> CallToolResult(
-                content = listOf(TextContent("Window resize failed: ${response.errorMessage ?: "unknown error"}")),
-                isError = true
-            )
-            else -> CallToolResult(content = listOf(TextContent("""{"success": true}""")))
-        }
-    } catch (e: WindowIdNotFoundException) {
-        CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
-    } catch (e: Exception) {
-        CallToolResult(content = listOf(TextContent("Window resize failed: ${e.message}")), isError = true)
     }
 
     val resultText = (result.content.firstOrNull() as? TextContent)?.text
     if (result.isError == true) logger.warn("resize_window: $resultText")
     else logger.debug { "resize_window: $resultText" }
-    return result
+    result
 }
 
 /** Thrown by [resolveWindowId] when an explicit 'window_id' does not match any registered window. */

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -38,6 +38,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import org.jetbrains.compose.devtools.api.ReloadCountState
 import org.jetbrains.compose.devtools.api.ReloadState
+import org.jetbrains.compose.devtools.api.UIErrorState
 import org.jetbrains.compose.devtools.api.WindowsState
 import org.jetbrains.compose.reload.DelicateHotReloadApi
 import org.jetbrains.compose.reload.core.HOT_RELOAD_VERSION
@@ -131,6 +132,9 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
                 "When connected, additionally returns reload state (ok/reloading/failed), last error if any " +
                 "(with 'lastErrorDetails' carrying additional diagnostic lines such as compiler output when " +
                 "a reload failed), and counts of successful and failed reloads since the application started. " +
+                "When a window is currently failing to render because of a runtime UI exception (distinct " +
+                "from a reload failure), 'uiErrorWindows' lists the affected window ids; call 'get_ui_error' " +
+                "for the message and stacktrace. " +
                 "Call this before take_screenshot to know if the application is available.",
             inputSchema = toolSchema(MaxErrorDetailLinesParam, required = emptyList())
         ) { request ->
@@ -164,6 +168,20 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
                 "click, ...) to target a specific window."
         ) { _ ->
             handleListWindows(orchestration)
+        }
+
+        addTool(
+            name = "get_ui_error",
+            description = "Get the runtime UI exception currently thrown while a single window renders its " +
+                "UI (e.g. an exception in a @Composable). " +
+                "Returns a JSON object with 'windowId' and 'hasError'; when 'hasError' is true it also " +
+                "contains 'message' and 'stacktrace' (a list of lines, capped by " +
+                "'max_error_detail_lines', with 'stacktraceTruncated' reporting how many lines were dropped). " +
+                "Defaults to the first registered window; pass 'window_id' to target a specific one " +
+                "('status' lists failing windows in 'uiErrorWindows').",
+            inputSchema = toolSchema(WindowIdParam, MaxErrorDetailLinesParam, required = emptyList())
+        ) { request ->
+            handleGetUIError(orchestration, request)
         }
 
         addTool(
@@ -324,6 +342,10 @@ private suspend fun handleStatus(
                 }
             put("successfulReloads", count.successfulReloads)
             put("failedReloads", count.failedReloads)
+            val uiErrorWindows = handle.states.get(UIErrorState).value.errors.keys
+            if (uiErrorWindows.isNotEmpty()) {
+                put("uiErrorWindows", buildJsonArray { uiErrorWindows.forEach { add(it.value) } })
+            }
         }.toString()))
     )
 }
@@ -442,6 +464,44 @@ private suspend fun handleListWindows(orchestration: StateFlow<OrchestrationHand
                 put("y", state.y)
                 put("width", state.width)
                 put("height", state.height)
+            }
+        }
+    }
+    return CallToolResult(content = listOf(TextContent(json.toString())))
+}
+
+private suspend fun handleGetUIError(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    toolRequest: CallToolRequest,
+): CallToolResult {
+    val handle = orchestration.value
+        ?: return CallToolResult(
+            content = listOf(TextContent("No application is currently connected. Use the 'status' tool to check availability.")),
+            isError = true
+        ).also { logger.info { "get_ui_error: no application connected" } }
+
+    val resolvedId = try {
+        resolveWindowId(handle, toolRequest.arguments)
+    } catch (e: WindowIdNotFoundException) {
+        return CallToolResult(content = listOf(TextContent(e.message ?: "Invalid window_id")), isError = true)
+    }
+
+    val error = handle.states.get(UIErrorState).value.errors[resolvedId]
+    val maxDetailLines = (toolRequest.arguments?.get("max_error_detail_lines")?.jsonPrimitive?.intOrNull
+        ?: DEFAULT_MAX_ERROR_DETAIL_LINES).coerceAtLeast(0)
+
+    logger.debug { "get_ui_error: window=$resolvedId hasError=${error != null}" }
+    val json = buildJsonObject {
+        put("windowId", resolvedId.value)
+        if (error == null) {
+            put("hasError", false)
+        } else {
+            put("hasError", true)
+            put("message", error.message)
+            val shown = error.stacktrace.take(maxDetailLines)
+            put("stacktrace", buildJsonArray { shown.forEach { add(it) } })
+            if (error.stacktrace.size > shown.size) {
+                put("stacktraceTruncated", error.stacktrace.size - shown.size)
             }
         }
     }

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -23,6 +23,7 @@ import kotlinx.io.asSource
 import kotlinx.io.buffered
 import org.jetbrains.compose.devtools.api.ReloadCountState
 import org.jetbrains.compose.devtools.api.ReloadState
+import org.jetbrains.compose.devtools.api.UIErrorState
 import org.jetbrains.compose.devtools.api.WindowsState
 import org.jetbrains.compose.devtools.api.WindowsState.WindowState
 import org.jetbrains.compose.reload.core.WindowId
@@ -1143,6 +1144,178 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Invalid window size"), "unexpected error message: $text")
+        }
+    }
+
+    /**
+     * Polls the `get_ui_error` tool (defaulting to the first registered window) until the returned
+     * JSON satisfies [predicate], or fails after 5 real-time seconds. Needed because orchestration
+     * state propagates to the tooling client asynchronously.
+     */
+    private suspend fun awaitUiErrors(client: Client, predicate: (String) -> Boolean): String {
+        val deadline = System.currentTimeMillis() + 5_000L
+        while (true) {
+            val text = (client.callTool("get_ui_error", emptyMap()).content.first() as TextContent).text
+            if (predicate(text)) return text
+            if (System.currentTimeMillis() > deadline) {
+                throw AssertionError("Timed out waiting for get_ui_error. Last: $text")
+            }
+            Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun `test - get_ui_error returns error when disconnected`() = runTest(timeout = 10.seconds) {
+        val orchestration = MutableStateFlow<OrchestrationHandle?>(null)
+        val client = createMcpClient(orchestration)
+
+        val result = client.callTool("get_ui_error", emptyMap())
+        assertEquals(true, result.isError)
+        val text = (result.content.first() as TextContent).text
+        assertTrue(text.contains("No application is currently connected"))
+    }
+
+    @Test
+    fun `test - get_ui_error reports no error for a healthy window`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+            registerSingleWindow(server, client)
+
+            val result = client.callTool("get_ui_error", emptyMap())
+            assertEquals("""{"windowId":"w-1","hasError":false}""", (result.content.first() as TextContent).text)
+        }
+    }
+
+    @Test
+    fun `test - get_ui_error returns the error for the default window`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+            registerSingleWindow(server, client)
+
+            server.update(UIErrorState) {
+                UIErrorState(linkedMapOf(
+                    WindowId("w-1") to UIErrorState.UIError(
+                        message = "boom",
+                        stacktrace = listOf("a.b.C.foo(C.kt:1)", "a.b.C.bar(C.kt:2)"),
+                    )
+                ))
+            }
+
+            val text = awaitUiErrors(client) { it.contains(""""hasError":true""") }
+            assertEquals(
+                """{"windowId":"w-1","hasError":true,"message":"boom",""" +
+                    """"stacktrace":["a.b.C.foo(C.kt:1)","a.b.C.bar(C.kt:2)"]}""",
+                text,
+            )
+        }
+    }
+
+    @Test
+    fun `test - get_ui_error targets explicit window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(WindowsState) {
+                WindowsState(linkedMapOf(
+                    WindowId("w-1") to windowState(0, 0, 100, 100),
+                    WindowId("w-2") to windowState(0, 0, 200, 200),
+                ))
+            }
+            awaitWindows(client, expectedCount = 2)
+
+            server.update(UIErrorState) {
+                UIErrorState(linkedMapOf(
+                    WindowId("w-1") to UIErrorState.UIError("one", emptyList()),
+                    WindowId("w-2") to UIErrorState.UIError("two", emptyList()),
+                ))
+            }
+            awaitUiErrors(client) { it.contains(""""hasError":true""") }
+
+            val result = client.callTool("get_ui_error", mapOf("window_id" to "w-2"))
+            assertEquals(
+                """{"windowId":"w-2","hasError":true,"message":"two","stacktrace":[]}""",
+                (result.content.first() as TextContent).text,
+            )
+        }
+    }
+
+    @Test
+    fun `test - get_ui_error returns error for unknown window_id`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+            registerSingleWindow(server, client)
+
+            val result = client.callTool("get_ui_error", mapOf("window_id" to "ghost"))
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
+        }
+    }
+
+    @Test
+    fun `test - get_ui_error truncates long stacktrace`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+            registerSingleWindow(server, client)
+
+            server.update(UIErrorState) {
+                UIErrorState(linkedMapOf(
+                    WindowId("w-1") to UIErrorState.UIError(
+                        "boom", (1..150).map { "line $it" },
+                    )
+                ))
+            }
+            awaitUiErrors(client) { it.contains(""""hasError":true""") }
+
+            val result = client.callTool("get_ui_error", mapOf("max_error_detail_lines" to 2))
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains(""""stacktrace":["line 1","line 2"]"""), "unexpected stacktrace: $text")
+            assertTrue(text.contains(""""stacktraceTruncated":148"""), "expected truncation count: $text")
+        }
+    }
+
+    @Test
+    fun `test - status includes uiErrorWindows when present`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(UIErrorState) {
+                UIErrorState(linkedMapOf(
+                    WindowId("w-1") to UIErrorState.UIError("boom", emptyList()),
+                ))
+            }
+            val text = awaitStatus(client, "uiErrorWindows")
+            assertTrue(text.contains(""""uiErrorWindows":["w-1"]"""), "unexpected status: $text")
         }
     }
 }

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.window.FrameWindowScope
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.update
+import org.jetbrains.compose.devtools.api.UIErrorState
 import org.jetbrains.compose.reload.InternalHotReloadApi
 import org.jetbrains.compose.reload.agent.orchestration
 import org.jetbrains.compose.reload.agent.sendAsync
@@ -29,6 +30,7 @@ import org.jetbrains.compose.reload.agent.sendBlocking
 import org.jetbrains.compose.reload.core.HotReloadEnvironment.reloadEffectsEnabled
 import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.createLogger
+import org.jetbrains.compose.reload.core.launchTask
 import org.jetbrains.compose.reload.core.debug
 import org.jetbrains.compose.reload.core.error
 import org.jetbrains.compose.reload.core.warn
@@ -103,6 +105,12 @@ public fun DevelopmentEntryPoint(
                 message = exception.message,
                 stacktrace = exception.stackTrace.toList()
             ).sendBlocking()
+            if (windowId != null) updateUIErrorState { errors ->
+                errors + (windowId to UIErrorState.UIError(
+                    message = exception.message,
+                    stacktrace = exception.stackTrace.map { it.toString() },
+                ))
+            }
 
         }.onSuccess {
             hotReloadState.update { state -> state.copy(uiError = null) }
@@ -111,6 +119,7 @@ public fun DevelopmentEntryPoint(
                 reloadRequestId = currentHotReloadState.reloadRequestId,
                 currentHotReloadState.iteration
             ).sendAsync()
+            if (windowId != null) updateUIErrorState { errors -> errors - windowId }
         }.getOrThrow()
     }
 
@@ -137,6 +146,14 @@ private inline fun <reified T : OrchestrationMessage> handleWindowRequests(
             .filterIsInstance<T>()
             .filter { request -> windowIdOf(request) == null || windowIdOf(request) == windowId }
             .collect { request -> respond(request).sendAsync() }
+    }
+}
+
+private fun updateUIErrorState(
+    update: (Map<WindowId, UIErrorState.UIError>) -> Map<WindowId, UIErrorState.UIError>
+) {
+    launchTask("update UIErrorState") {
+        orchestration.update(UIErrorState) { current -> UIErrorState(update(current.errors)) }
     }
 }
 


### PR DESCRIPTION
Share UI errors as orchestration state + expose them over MCP via `get_ui_error` tool.

**Implementation note:**
Promotes the devtools-only `ErrorUIState` into a shared `UIErrorState` orchestration
state.



