### PR TITLE
[mcpserver] Add get_logs tool

### DIFF
--- a/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/logging.kt
+++ b/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/logging.kt
@@ -9,6 +9,7 @@ import org.jetbrains.compose.reload.core.HotReloadEnvironment
 import org.jetbrains.compose.reload.core.Logger
 import org.jetbrains.compose.reload.core.Queue
 import org.jetbrains.compose.reload.core.WorkerThread
+import org.jetbrains.compose.reload.core.chrLogFile
 import org.jetbrains.compose.reload.core.createLogger
 import org.jetbrains.compose.reload.core.debug
 import org.jetbrains.compose.reload.core.displayString
@@ -24,7 +25,6 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.LogMessag
 import org.jetbrains.compose.reload.orchestration.toMessage
 import java.time.LocalDateTime
 import kotlin.io.path.createParentDirectories
-import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.outputStream
 
 private val logger = createLogger()
@@ -96,7 +96,7 @@ internal fun startWritingLogs() = launchTask task@{
 
     withThread(loggerThread) {
         val pidFile = HotReloadEnvironment.pidFile
-        val logFile = pidFile?.resolveSibling(pidFile.nameWithoutExtension + ".chr.log")
+        val logFile = pidFile?.chrLogFile
         val logFileWriter = logFile?.createParentDirectories()?.outputStream()?.bufferedWriter()
         invokeOnFinish { logFileWriter?.close() }
         invokeOnStop { logFileWriter?.close() }

--- a/hot-reload-core/api/hot-reload-core.api
+++ b/hot-reload-core/api/hot-reload-core.api
@@ -358,6 +358,7 @@ public final class org/jetbrains/compose/reload/core/PidFileInfoKt {
 	public static final fun PidFileInfo (Ljava/util/Properties;)Lorg/jetbrains/compose/reload/core/PidFileInfo;
 	public static final fun PidFileInfo ([B)Lorg/jetbrains/compose/reload/core/Either;
 	public static final fun deleteMyPidFileIfExists (Ljava/nio/file/Path;Lorg/jetbrains/compose/reload/core/PidFileInfo;)Z
+	public static final fun getChrLogFile (Ljava/nio/file/Path;)Ljava/nio/file/Path;
 	public static final fun writePidFile (Ljava/nio/file/Path;Lorg/jetbrains/compose/reload/core/PidFileInfo;)V
 }
 

--- a/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/PidFileInfo.kt
+++ b/hot-reload-core/src/main/kotlin/org/jetbrains/compose/reload/core/PidFileInfo.kt
@@ -12,6 +12,7 @@ import java.util.Properties
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.inputStream
 import kotlin.io.path.isRegularFile
+import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.outputStream
 
 @DelicateHotReloadApi
@@ -61,6 +62,10 @@ public fun Path.writePidFile(pidFileInfo: PidFileInfo) {
     }
 }
 
+
+/** The agent log file associated with this PID file. */
+public val Path.chrLogFile: Path
+    get() = resolveSibling(nameWithoutExtension + ".chr.log")
 
 /**
  * Deletes the pid file if its content matches the given [expected] [PidFileInfo]

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.runInterruptible
 import org.jetbrains.compose.reload.InternalHotReloadApi
 import org.jetbrains.compose.reload.core.HotReloadEnvironment
 import org.jetbrains.compose.reload.core.PidFileInfo
+import org.jetbrains.compose.reload.core.chrLogFile
 import org.jetbrains.compose.reload.core.createLogger
 import org.jetbrains.compose.reload.core.error
 import org.jetbrains.compose.reload.core.getOrNull
@@ -52,11 +53,13 @@ fun main(args: Array<String>) {
 
     logger.info("MCP server starting. Watching PID file: $pidFile")
 
+    val logFile = pidFile.chrLogFile
+
     runBlocking {
         val orchestration = connectionLoop(pidFile)
             .stateIn(this, SharingStarted.Eagerly, null)
 
-        startMcpServer(orchestration, protocolOut)
+        startMcpServer(orchestration, protocolOut, logFile)
     }
 }
 

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -65,18 +65,25 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.WindowRes
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.WindowResizeResult
 import org.jetbrains.compose.reload.orchestration.asChannel
 import java.io.OutputStream
+import java.nio.file.Path
 import java.util.Base64
+import kotlin.io.path.bufferedReader
+import kotlin.io.path.isRegularFile
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 private val logger = createLogger()
 
-internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle?>, protocolOut: OutputStream) {
+internal suspend fun startMcpServer(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    protocolOut: OutputStream,
+    logFile: Path,
+) {
     val transport = StdioServerTransport(
         inputStream = System.`in`.asSource().buffered(),
         outputStream = protocolOut.asSink().buffered()
     )
-    startMcpServer(orchestration, transport)
+    startMcpServer(orchestration, transport, logFile)
 }
 
 /** A single input property in a tool's JSON schema. */
@@ -98,6 +105,9 @@ private val MaxErrorDetailLinesParam = Property("max_error_detail_lines", "integ
         "(default $DEFAULT_MAX_ERROR_DETAIL_LINES). When the details are longer, " +
         "'lastErrorDetailsTruncated' reports how many lines were dropped. Use 0 to omit the details " +
         "entirely.")
+private val LogLimitParam = Property("limit", "integer",
+    description = "Maximum number of most recent log lines to return (default $DEFAULT_LOG_LINES). " +
+        "Use 0 to return all available lines.")
 
 /** Builds a [ToolSchema] from [properties]; by default all of them are required. */
 private fun toolSchema(
@@ -116,7 +126,11 @@ private fun toolSchema(
 )
 
 @OptIn(DelicateHotReloadApi::class)
-internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle?>, transport: Transport) {
+internal suspend fun startMcpServer(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    transport: Transport,
+    logFile: Path,
+) {
     val server = Server(
         serverInfo = Implementation(name = "compose-hot-reload", version = HOT_RELOAD_VERSION),
         options = ServerOptions(
@@ -182,6 +196,18 @@ internal suspend fun startMcpServer(orchestration: StateFlow<OrchestrationHandle
             inputSchema = toolSchema(WindowIdParam, MaxErrorDetailLinesParam, required = emptyList())
         ) { request ->
             handleGetUIError(orchestration, request)
+        }
+
+        addTool(
+            name = "get_logs",
+            description = "Return recent log output from the running Compose application. " +
+                "Returns the most recent log lines as plain text, oldest first. Includes the " +
+                "application's runtime log messages and critical exceptions; build/reload status is " +
+                "reported by the 'reload' and 'status' tools instead. Requires a connected " +
+                "application; use the 'status' tool first to check availability.",
+            inputSchema = toolSchema(LogLimitParam, required = emptyList())
+        ) { request ->
+            handleGetLogs(orchestration, logFile, request)
         }
 
         addTool(
@@ -525,6 +551,48 @@ private suspend fun handleGetUIError(
         }
     }
     textResult(json.toString())
+}
+
+/**
+ * Default number of trailing log lines returned by 'get_logs'. Overridable per call via the 'limit'
+ * parameter (use 0 to return everything available).
+ */
+private const val DEFAULT_LOG_LINES = 200
+
+/**
+ * Returns recent application log output by tailing the agent's '.chr.log' file.
+ * The file is written by the application/agent process,
+ * so the returned lines include output emitted before this MCP server attached. Requires a connected
+ * application; returns the standard "not connected" error otherwise.
+ */
+private suspend fun handleGetLogs(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    logFile: Path,
+    request: CallToolRequest,
+): CallToolResult = withConnection(orchestration, "get_logs") { _ ->
+    val limit = (request.arguments?.get("limit")?.jsonPrimitive?.intOrNull ?: DEFAULT_LOG_LINES)
+        .coerceAtLeast(0)
+    if (!logFile.isRegularFile()) {
+        logger.debug { "get_logs: no log file at $logFile" }
+        return@withConnection textResult("No logs available (the application has not produced any logs yet).")
+    }
+    val lines = tailLines(logFile, if (limit == 0) Int.MAX_VALUE else limit)
+    logger.debug { "get_logs: returning ${lines.size} line(s) from $logFile" }
+    textResult(lines.joinToString("\n"))
+}
+
+/**
+ * Reads [file] streaming and retains only the last [maxLines] lines (oldest first).
+ */
+private fun tailLines(file: Path, maxLines: Int): List<String> {
+    val deque = ArrayDeque<String>()
+    file.bufferedReader().useLines { lines ->
+        lines.forEach { line ->
+            deque.addLast(line)
+            if (deque.size > maxLines) deque.removeFirst()
+        }
+    }
+    return deque.toList()
 }
 
 private suspend fun handleTakeScreenshot(

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -50,6 +50,10 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationServer
 import org.jetbrains.compose.reload.orchestration.startOrchestrationServer
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
+import java.nio.file.Path
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
+import kotlin.io.path.writeText
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -73,7 +77,11 @@ class McpServerTest {
         client = null
     }
 
-    private suspend fun CoroutineScope.createMcpClient(orchestration: MutableStateFlow<OrchestrationHandle?>): Client {
+    private suspend fun CoroutineScope.createMcpClient(
+        orchestration: MutableStateFlow<OrchestrationHandle?>,
+        // Defaults to a path that does not exist, modelling "no logs written yet".
+        logFile: Path = createTempDirectory().resolve("absent.chr.log"),
+    ): Client {
         val serverIn = PipedInputStream()
         val clientOut = PipedOutputStream(serverIn)
         val clientIn = PipedInputStream()
@@ -89,7 +97,7 @@ class McpServerTest {
             clientOut.asSink().buffered()
         )
 
-        launch { startMcpServer(orchestration, serverTransport) }
+        launch { startMcpServer(orchestration, serverTransport, logFile) }
 
         val client = Client(Implementation(name = "test-client", version = "1.0.0"))
         client.connect(clientTransport)
@@ -1316,6 +1324,100 @@ class McpServerTest {
             }
             val text = awaitStatus(client, "uiErrorWindows")
             assertTrue(text.contains(""""uiErrorWindows":["w-1"]"""), "unexpected status: $text")
+        }
+    }
+
+    @Test
+    fun `test - get_logs returns error when disconnected`() = runTest(timeout = 10.seconds) {
+        val logFile = createTempFile("chr", ".log")
+        logFile.writeText("line 1\nline 2")
+
+        val orchestration = MutableStateFlow<OrchestrationHandle?>(null)
+        val client = createMcpClient(orchestration, logFile = logFile)
+
+        val result = client.callTool("get_logs", emptyMap())
+        assertEquals(true, result.isError)
+        val text = (result.content.first() as TextContent).text
+        assertTrue(text.contains("No application is currently connected"))
+    }
+
+    @Test
+    fun `test - get_logs returns a message when no log file exists`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            // Use the default logFile, which points at a non-existent file.
+            val client = createMcpClient(orchestration)
+
+            val result = client.callTool("get_logs", emptyMap())
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("No logs available"), "unexpected result: $text")
+        }
+    }
+
+    @Test
+    fun `test - get_logs returns all lines by default`() = runTest(timeout = 10.seconds) {
+        val logFile = createTempFile("chr", ".log")
+        logFile.writeText("line 1\nline 2\nline 3")
+
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration, logFile = logFile)
+
+            val result = client.callTool("get_logs", emptyMap())
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertEquals("line 1\nline 2\nline 3", text)
+        }
+    }
+
+    @Test
+    fun `test - get_logs honors the limit parameter`() = runTest(timeout = 10.seconds) {
+        val logFile = createTempFile("chr", ".log")
+        logFile.writeText((1..10).joinToString("\n") { "line $it" })
+
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration, logFile = logFile)
+
+            val result = client.callTool("get_logs", mapOf("limit" to 3))
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            // Returns the most recent lines, oldest first.
+            assertEquals("line 8\nline 9\nline 10", text)
+        }
+    }
+
+    @Test
+    fun `test - get_logs returns everything when limit is zero`() = runTest(timeout = 10.seconds) {
+        val logFile = createTempFile("chr", ".log")
+        val expected = (1..500).joinToString("\n") { "line $it" }
+        logFile.writeText(expected)
+
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration, logFile = logFile)
+
+            val result = client.callTool("get_logs", mapOf("limit" to 0))
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertEquals(expected, text)
         }
     }
 }


### PR DESCRIPTION
**Implementation note:** retrieves (limited) logs from `<pidFile>.chr.log` that allows an AI agent to see the picture from very start of the application. 