### PR TITLE
[mcpserver] Introduce `await_reload` tool for  `--auto` build mode

### DIFF
--- a/hot-reload-devtools-api/api/hot-reload-devtools-api.api
+++ b/hot-reload-devtools-api/api/hot-reload-devtools-api.api
@@ -1,3 +1,21 @@
+public final class org/jetbrains/compose/devtools/api/BuildModeState : org/jetbrains/compose/reload/orchestration/OrchestrationState {
+	public static final field $stable I
+	public static final field Key Lorg/jetbrains/compose/devtools/api/BuildModeState$Key;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isContinuous ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/compose/devtools/api/BuildModeState$Key : org/jetbrains/compose/reload/orchestration/OrchestrationStateKey {
+	public fun getDefault ()Lorg/jetbrains/compose/devtools/api/BuildModeState;
+	public synthetic fun getDefault ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationState;
+	public fun getId ()Lorg/jetbrains/compose/reload/orchestration/OrchestrationStateId;
+}
+
 public abstract interface class org/jetbrains/compose/devtools/api/Recompiler {
 	public abstract fun buildAndReload-lno2V2A (Lorg/jetbrains/compose/devtools/api/RecompilerContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getName ()Ljava/lang/String;

--- a/hot-reload-devtools-api/src/main/kotlin/org/jetbrains/compose/devtools/api/BuildModeState.kt
+++ b/hot-reload-devtools-api/src/main/kotlin/org/jetbrains/compose/devtools/api/BuildModeState.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.devtools.api
+
+import org.jetbrains.compose.reload.ExperimentalHotReloadApi
+import org.jetbrains.compose.reload.core.Try
+import org.jetbrains.compose.reload.core.Type
+import org.jetbrains.compose.reload.core.decode
+import org.jetbrains.compose.reload.core.encodeByteArray
+import org.jetbrains.compose.reload.core.readFields
+import org.jetbrains.compose.reload.core.tryDecode
+import org.jetbrains.compose.reload.core.type
+import org.jetbrains.compose.reload.core.writeFields
+import org.jetbrains.compose.reload.orchestration.OrchestrationState
+import org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
+import org.jetbrains.compose.reload.orchestration.OrchestrationStateId
+import org.jetbrains.compose.reload.orchestration.OrchestrationStateKey
+import org.jetbrains.compose.reload.orchestration.stateId
+
+/**
+ * Broadcasts how the application's recompiler is driven.
+ *
+ * When [isContinuous] is `true`, the build runs in continuous (`--auto`) mode: a perpetual Gradle
+ * `-t` process recompiles and reloads autonomously on source changes. Manual reload requests
+ * (`RecompileRequest`) are not consumed in this mode, so tooling clients must observe the autonomous
+ * reload lifecycle instead of triggering one.
+ *
+ * Published once at startup by the devtools process (which knows the mode via
+ * `HotReloadEnvironment.gradleBuildContinuous`) and consumed by tooling clients such as the MCP server,
+ * which run in a separate process and cannot read that environment flag directly.
+ */
+@ExperimentalHotReloadApi
+public class BuildModeState(
+    public val isContinuous: Boolean = false
+) : OrchestrationState {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BuildModeState) return false
+        if (other.isContinuous != isContinuous) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return isContinuous.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BuildModeState(isContinuous=$isContinuous)"
+    }
+
+    public companion object Key : OrchestrationStateKey<BuildModeState>() {
+        override val id: OrchestrationStateId<BuildModeState> = stateId()
+        override val default: BuildModeState = BuildModeState()
+    }
+}
+
+internal class BuildModeStateEncoder : OrchestrationStateEncoder<BuildModeState> {
+    override val type: Type<BuildModeState> = type()
+
+    override fun encode(state: BuildModeState): ByteArray = encodeByteArray {
+        writeFields(
+            "isContinuous" to encodeByteArray { writeBoolean(state.isContinuous) }
+        )
+    }
+
+    override fun decode(data: ByteArray): Try<BuildModeState> = data.tryDecode {
+        val fields = readFields()
+        BuildModeState(
+            fields["isContinuous"]?.decode { readBoolean() } ?: error("Missing field `isContinuous`")
+        )
+    }
+}

--- a/hot-reload-devtools-api/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
+++ b/hot-reload-devtools-api/src/main/resources/META-INF/services/org.jetbrains.compose.reload.orchestration.OrchestrationStateEncoder
@@ -7,3 +7,4 @@ org.jetbrains.compose.devtools.api.ReloadCountStateEncoder
 org.jetbrains.compose.devtools.api.WindowsStateEncoder
 org.jetbrains.compose.devtools.api.VirtualTimeStateEncoder
 org.jetbrains.compose.devtools.api.UIErrorStateEncoder
+org.jetbrains.compose.devtools.api.BuildModeStateEncoder

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/main.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/main.kt
@@ -14,6 +14,7 @@ import io.sellmair.evas.States
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import org.jetbrains.compose.devtools.states.launchBuildModeStateActor
 import org.jetbrains.compose.devtools.states.launchConsoleLogUIState
 import org.jetbrains.compose.devtools.states.launchErrorUIState
 import org.jetbrains.compose.devtools.states.launchNotificationsUIState
@@ -45,6 +46,8 @@ internal fun CoroutineScope.launchApplicationStates() {
 
     launchReloadStateActor()
     launchReloadUIState()
+
+    launchBuildModeStateActor()
 
     launchRestartActor()
     launchNotificationsUIState()

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/buildModeStateActor.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/buildModeStateActor.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024-2025 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.devtools.states
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.devtools.api.BuildModeState
+import org.jetbrains.compose.devtools.orchestration
+import org.jetbrains.compose.reload.DelicateHotReloadApi
+import org.jetbrains.compose.reload.core.HotReloadEnvironment
+
+/**
+ * Publishes the recompiler's build mode so tooling clients (e.g. the MCP server) running in a
+ * separate process can discover it. The mode is fixed at startup and never changes, so this is a
+ * one-shot publish.
+ */
+@OptIn(DelicateHotReloadApi::class)
+fun CoroutineScope.launchBuildModeStateActor() = launch {
+    orchestration.update(BuildModeState.Key) {
+        BuildModeState(isContinuous = HotReloadEnvironment.gradleBuildContinuous)
+    }
+}

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpMain.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.runInterruptible
 import org.jetbrains.compose.reload.InternalHotReloadApi
 import org.jetbrains.compose.reload.core.HotReloadEnvironment
 import org.jetbrains.compose.reload.core.PidFileInfo
-import org.jetbrains.compose.reload.core.chrLogFile
 import org.jetbrains.compose.reload.core.createLogger
 import org.jetbrains.compose.reload.core.error
 import org.jetbrains.compose.reload.core.getOrNull
@@ -53,13 +52,11 @@ fun main(args: Array<String>) {
 
     logger.info("MCP server starting. Watching PID file: $pidFile")
 
-    val logFile = pidFile.chrLogFile
-
     runBlocking {
         val orchestration = connectionLoop(pidFile)
             .stateIn(this, SharingStarted.Eagerly, null)
 
-        startMcpServer(orchestration, protocolOut, logFile)
+        startMcpServer(orchestration, protocolOut, pidFile)
     }
 }
 

--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -18,6 +18,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapNotNull
@@ -37,6 +38,7 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import org.jetbrains.compose.devtools.api.BuildModeState
 import org.jetbrains.compose.devtools.api.ReloadCountState
 import org.jetbrains.compose.devtools.api.ReloadState
 import org.jetbrains.compose.devtools.api.UIErrorState
@@ -44,6 +46,7 @@ import org.jetbrains.compose.devtools.api.WindowsState
 import org.jetbrains.compose.reload.DelicateHotReloadApi
 import org.jetbrains.compose.reload.core.HOT_RELOAD_VERSION
 import org.jetbrains.compose.reload.core.WindowId
+import org.jetbrains.compose.reload.core.chrLogFile
 import org.jetbrains.compose.reload.core.createLogger
 import org.jetbrains.compose.reload.core.debug
 import org.jetbrains.compose.reload.core.info
@@ -67,6 +70,7 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RestartRe
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.WindowResizeRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.WindowResizeResult
 import org.jetbrains.compose.reload.orchestration.asChannel
+import org.jetbrains.compose.reload.orchestration.flowOf
 import java.io.OutputStream
 import java.nio.file.Path
 import java.util.Base64
@@ -75,6 +79,7 @@ import kotlin.io.path.createParentDirectories
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.writeBytes
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private val logger = createLogger()
@@ -82,13 +87,13 @@ private val logger = createLogger()
 internal suspend fun startMcpServer(
     orchestration: StateFlow<OrchestrationHandle?>,
     protocolOut: OutputStream,
-    logFile: Path,
+    pidFile: Path,
 ) {
     val transport = StdioServerTransport(
         inputStream = System.`in`.asSource().buffered(),
         outputStream = protocolOut.asSink().buffered()
     )
-    startMcpServer(orchestration, transport, logFile)
+    startMcpServer(orchestration, transport, pidFile)
 }
 
 /** A single input property in a tool's JSON schema. */
@@ -142,7 +147,7 @@ private fun toolSchema(
 internal suspend fun startMcpServer(
     orchestration: StateFlow<OrchestrationHandle?>,
     transport: Transport,
-    logFile: Path,
+    pidFile: Path,
 ) {
     val server = Server(
         serverInfo = Implementation(name = "compose-hot-reload", version = HOT_RELOAD_VERSION),
@@ -170,8 +175,9 @@ internal suspend fun startMcpServer(
 
         addTool(
             name = "reload",
-            description = "Trigger a hot reload of the running Compose application: recompiles the " +
-                "project sources and reloads the changed classes into the live application without " +
+            description = "Trigger a hot reload of the running Compose application " +
+                "when the application was NOT started with continues build mode (--auto): " +
+                "recompiles the project sources and reloads the changed classes into the live application without " +
                 "restarting it. Call this after editing source files to apply the changes. " +
                 "Returns {\"success\": true, \"reloaded\": true} when changed classes were reloaded, " +
                 "{\"success\": true, \"reloaded\": false} when compilation succeeded but nothing changed, " +
@@ -179,10 +185,26 @@ internal suspend fun startMcpServer(
                 "If the reload does not finish within 'timeout_seconds', returns " +
                 "{\"status\": \"reloading\"} (not an error): the reload is still running, so poll the " +
                 "'status' tool until 'reloadState' is no longer 'reloading'. " +
-                "Use the 'status' tool first to check if the application is connected.",
+                "Use the 'status' tool first to check if the application is connected and its build mode.",
             inputSchema = toolSchema(ReloadTimeoutParam, required = emptyList())
         ) { request ->
             handleReload(orchestration, request)
+        }
+
+        addTool(
+            name = "await_reload",
+            description = "Await a hot reload when the application was started with continuous build mode (--auto): " +
+                "the build recompiles and reloads autonomously, and this tool waits for that reload to finish " +
+                "and reports the resulting state. Call this after editing source files to let the autonomous build apply changes. " +
+                "Returns {\"success\": true} once the application has come into a healthy (reloaded) state, " +
+                "and an error when the build or reload fails. " +
+                "If the reload does not finish within 'timeout_seconds', returns " +
+                "{\"status\": \"reloading\"} (not an error): still waiting for the build to complete, so poll the " +
+                "'status' tool until 'reloadState' is no longer 'reloading'. " +
+                "Use the 'status' tool first to check if the application is connected and its build mode.",
+            inputSchema = toolSchema(ReloadTimeoutParam, required = emptyList())
+        ) { request ->
+            handleAwaitReload(orchestration, request)
         }
 
         addTool(
@@ -220,7 +242,7 @@ internal suspend fun startMcpServer(
                 "application; use the 'status' tool first to check availability.",
             inputSchema = toolSchema(LogLimitParam, required = emptyList())
         ) { request ->
-            handleGetLogs(orchestration, logFile, request)
+            handleGetLogs(orchestration, pidFile.chrLogFile, request)
         }
 
         addTool(
@@ -436,6 +458,7 @@ private suspend fun handleStatus(
     }
     val state = handle.states.get(ReloadState).value
     val count = handle.states.get(ReloadCountState).value
+    val buildContinuous = handle.states.get(BuildModeState).value.isContinuous
     val reloadStateStr = when (state) {
         is ReloadState.Ok -> "ok"
         is ReloadState.Reloading -> "reloading"
@@ -444,6 +467,7 @@ private suspend fun handleStatus(
     logger.debug { "status: connected reloadState=$reloadStateStr" }
     return textResult(buildJsonObject {
             put("connected", true)
+            put("buildContinuous", buildContinuous)
             put("reloadState", reloadStateStr)
             put("lastError", (state as? ReloadState.Failed)?.reason)
             val maxDetailLines = (toolRequest.arguments?.get("max_error_detail_lines")?.jsonPrimitive?.intOrNull
@@ -564,6 +588,67 @@ private suspend fun handleListWindows(orchestration: StateFlow<OrchestrationHand
         }
         textResult(json.toString())
     }
+
+/**
+ * How long to wait for the continuous build to pick up the latest edit (i.e. for [ReloadState] to
+ * become [ReloadState.Reloading]) before concluding that nothing changed.
+ */
+private val WAIT_FOR_RELOAD_TO_START_TIMEOUT = 500.milliseconds
+
+/**
+ * Awaits reload: observes the autonomous (continuous-build) reload through [ReloadState] and
+ * reports whether the application has come into a healthy state.
+ *
+ * Returns within [timeoutSeconds], degrading to a 'poll status' response if a reload is still running.
+ */
+private suspend fun handleAwaitReload(
+    orchestration: StateFlow<OrchestrationHandle?>,
+    toolRequest: CallToolRequest,
+): CallToolResult = withConnection(orchestration, "await_reload") { handle ->
+    val timeoutSeconds = (toolRequest.arguments?.get("timeout_seconds")?.jsonPrimitive?.intOrNull
+        ?: DEFAULT_RELOAD_TIMEOUT_SECONDS).coerceAtLeast(1)
+    val timeout = timeoutSeconds.seconds
+    logger.info { "await_reload: observing autonomous reload (timeout ${timeoutSeconds}s)" }
+
+    val stateFlow = handle.states.flowOf(ReloadState)
+
+    // If the application is idle, give the continuous build a brief moment to pick up a pending edit.
+    if (handle.states.get(ReloadState).value !is ReloadState.Reloading) {
+        val started = withTimeoutOrNull(minOf(timeout, WAIT_FOR_RELOAD_TO_START_TIMEOUT)) {
+            stateFlow.filterIsInstance<ReloadState.Reloading>().firstOrNull()
+        }
+        // Nothing started reloading: report the current (settled) state.
+        if (started == null) return@withConnection awaitReloadResult(handle.states.get(ReloadState).value, timeoutSeconds)
+    }
+
+    // A reload is in progress: wait for it to finish, bounded by the timeout.
+    val reloadState = withTimeoutOrNull(timeout) { stateFlow.firstOrNull { it !is ReloadState.Reloading } }
+    return@withConnection awaitReloadResult(reloadState, timeoutSeconds)
+}
+
+/**
+ * Maps [reloadState] to an `await_reload` result. A `null` or still-[ReloadState.Reloading]
+ * [reloadState] means the reload did not finish within the timeout, so the client is asked to poll 'status'.
+ */
+private fun awaitReloadResult(reloadState: ReloadState?, timeoutSeconds: Int): CallToolResult = when (reloadState) {
+    is ReloadState.Ok -> {
+        logger.info { "await_reload: application is up to date (--auto mode)" }
+        textResult("""{"success":true}""")
+    }
+
+    is ReloadState.Failed -> {
+        logger.warn("await_reload: reload failed (--auto mode): ${reloadState.reason}")
+        errorResult("Reload failed: ${reloadState.reason ?: "unknown error"}")
+    }
+
+    else -> {
+        logger.info { "await_reload: still in progress after ${timeoutSeconds}s; instructing client to poll 'status'" }
+        textResult(
+            """{"status":"reloading","message":"Reload still in progress after ${timeoutSeconds}s. """ +
+                """Poll the 'status' tool until 'reloadState' is no longer 'reloading', then check 'lastError'."}"""
+        )
+    }
+}
 
 private suspend fun handleGetUIError(
     orchestration: StateFlow<OrchestrationHandle?>,

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -15,6 +15,9 @@ import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -24,14 +27,18 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered
+import org.jetbrains.compose.devtools.api.BuildModeState
 import org.jetbrains.compose.devtools.api.ReloadCountState
 import org.jetbrains.compose.devtools.api.ReloadState
 import org.jetbrains.compose.devtools.api.UIErrorState
 import org.jetbrains.compose.devtools.api.WindowsState
 import org.jetbrains.compose.devtools.api.WindowsState.WindowState
+import org.jetbrains.compose.reload.core.PidFileInfo
 import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.awaitOrThrow
+import org.jetbrains.compose.reload.core.chrLogFile
 import org.jetbrains.compose.reload.core.getOrThrow
+import org.jetbrains.compose.reload.core.writePidFile
 import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.CleanCompositionRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RecompileRequest
@@ -69,6 +76,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class McpServerTest {
@@ -88,8 +96,9 @@ class McpServerTest {
 
     private suspend fun CoroutineScope.createMcpClient(
         orchestration: MutableStateFlow<OrchestrationHandle?>,
-        // Defaults to a path that does not exist, modelling "no logs written yet".
-        logFile: Path = createTempDirectory().resolve("absent.chr.log"),
+        // Defaults to a path that does not exist, modelling "no logs written yet" and a non-continuous build.
+        // The associated log file is 'pidFile.chrLogFile'.
+        pidFile: Path = createTempDirectory().resolve("absent.pid"),
     ): Client {
         val serverIn = PipedInputStream()
         val clientOut = PipedOutputStream(serverIn)
@@ -106,7 +115,7 @@ class McpServerTest {
             clientOut.asSink().buffered()
         )
 
-        launch { startMcpServer(orchestration, serverTransport, logFile) }
+        launch { startMcpServer(orchestration, serverTransport, pidFile) }
 
         val client = Client(Implementation(name = "test-client", version = "1.0.0"))
         client.connect(clientTransport)
@@ -154,7 +163,26 @@ class McpServerTest {
 
             val result = client.callTool("status", emptyMap())
             val text = (result.content.first() as TextContent).text
-            assertEquals("""{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""", text)
+            assertEquals("""{"connected":true,"buildContinuous":false,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""", text)
+        }
+    }
+
+    @Test
+    fun `test - status reports buildContinuous when in auto mode`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            server.update(BuildModeState) { BuildModeState(isContinuous = true) }
+            val text = awaitStatus(client, """"buildContinuous":true""")
+            assertEquals(
+                """{"connected":true,"buildContinuous":true,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""",
+                text,
+            )
         }
     }
 
@@ -418,7 +446,7 @@ class McpServerTest {
         // Connected
         val result1 = client.callTool("status", emptyMap())
         assertEquals(
-            """{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""",
+            """{"connected":true,"buildContinuous":false,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""",
             (result1.content.first() as TextContent).text
         )
 
@@ -455,7 +483,7 @@ class McpServerTest {
 
             val text = awaitStatus(client, """"reloadState":"ok"""")
             assertEquals(
-                """{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""",
+                """{"connected":true,"buildContinuous":false,"reloadState":"ok","lastError":null,"successfulReloads":0,"failedReloads":0}""",
                 text,
             )
         }
@@ -474,7 +502,7 @@ class McpServerTest {
             server.update(ReloadState) { ReloadState.Reloading() }
             val text = awaitStatus(client, """"reloadState":"reloading"""")
             assertEquals(
-                """{"connected":true,"reloadState":"reloading","lastError":null,"successfulReloads":0,"failedReloads":0}""",
+                """{"connected":true,"buildContinuous":false,"reloadState":"reloading","lastError":null,"successfulReloads":0,"failedReloads":0}""",
                 text,
             )
         }
@@ -495,7 +523,7 @@ class McpServerTest {
             }
             val text = awaitStatus(client, """"reloadState":"failed"""")
             assertEquals(
-                """{"connected":true,"reloadState":"failed","lastError":"boom",""" +
+                """{"connected":true,"buildContinuous":false,"reloadState":"failed","lastError":"boom",""" +
                     """"lastErrorDetails":["line one","line two"],""" +
                     """"successfulReloads":0,"failedReloads":0}""",
                 text,
@@ -542,7 +570,7 @@ class McpServerTest {
             val result = client.callTool("status", mapOf("max_error_detail_lines" to 1))
             val text = (result.content.first() as TextContent).text
             assertEquals(
-                """{"connected":true,"reloadState":"failed","lastError":"boom",""" +
+                """{"connected":true,"buildContinuous":false,"reloadState":"failed","lastError":"boom",""" +
                     """"lastErrorDetails":["a"],"lastErrorDetailsTruncated":2,""" +
                     """"successfulReloads":0,"failedReloads":0}""",
                 text,
@@ -568,7 +596,7 @@ class McpServerTest {
             val result = client.callTool("status", mapOf("max_error_detail_lines" to 0))
             val text = (result.content.first() as TextContent).text
             assertEquals(
-                """{"connected":true,"reloadState":"failed","lastError":"boom",""" +
+                """{"connected":true,"buildContinuous":false,"reloadState":"failed","lastError":"boom",""" +
                     """"successfulReloads":0,"failedReloads":0}""",
                 text,
             )
@@ -589,7 +617,7 @@ class McpServerTest {
             server.update(ReloadCountState) { ReloadCountState(it.successfulReloads + 1, it.failedReloads) }
             val text = awaitStatus(client, """"successfulReloads":1""")
             assertEquals(
-                """{"connected":true,"reloadState":"ok","lastError":null,"successfulReloads":1,"failedReloads":0}""",
+                """{"connected":true,"buildContinuous":false,"reloadState":"ok","lastError":null,"successfulReloads":1,"failedReloads":0}""",
                 text,
             )
         }
@@ -1116,6 +1144,111 @@ class McpServerTest {
         }
     }
 
+    /** A pid file whose associated log file ('pidFile.chrLogFile') contains [logContent]. */
+    private fun pidFileWithLogs(logContent: String): Path = createTempFile("mcp-test", ".pid").also { file ->
+        file.chrLogFile.writeText(logContent)
+    }
+
+    @Test
+    fun `test - reload in auto mode reports success when the reload happens`() =
+        runTest(timeout = 20.seconds) {
+            val server = startOrchestrationServer()
+            server.use {
+                val port = server.port.awaitOrThrow()
+                val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+                // In --auto mode no RecompileRequest is expected.
+                var sawRecompileRequest = false
+                val recompileRequestMonitor = launch {
+                    server.asFlow().filterIsInstance<RecompileRequest>().collect { sawRecompileRequest = true }
+                }
+
+                val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+                val client = createMcpClient(orchestration)
+
+                // The autonomous build is reloading, then set into a healthy state.
+                server.update(ReloadState) { ReloadState.Reloading() }
+                val reload = launch(Dispatchers.IO) {
+                    delay(200.milliseconds)
+                    server.update(ReloadState) { ReloadState.Ok() }
+                }
+
+                val result = client.callTool("await_reload", mapOf("timeout_seconds" to 10))
+                val resultText = (result.content.first() as TextContent).text
+                assertNotEquals(true, result.isError, "unexpected error result: $resultText")
+                assertEquals("""{"success":true}""", resultText)
+                assertEquals(false, sawRecompileRequest, "reload must not send a RecompileRequest in auto mode")
+                reload.cancel()
+                recompileRequestMonitor.cancel()
+            }
+        }
+
+    @Test
+    fun `test - reload in auto mode reports success when nothing reloads`() = runTest(timeout = 20.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            var sawRecompileRequest = false
+            val recompileRequestMonitor = launch {
+                server.asFlow().filterIsInstance<RecompileRequest>().collect { sawRecompileRequest = true }
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            // No build activity at all: the call must resolve quickly to 'no changes', not hit the timeout.
+            val result = client.callTool("await_reload", mapOf("timeout_seconds" to 2))
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertEquals("""{"success":true}""", text)
+            assertEquals(false, sawRecompileRequest, "reload must not send a RecompileRequest in auto mode")
+            recompileRequestMonitor.cancel()
+        }
+    }
+
+    @Test
+    fun `test - reload in auto mode reports failure`() = runTest(timeout = 20.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            // A build is in progress, then fails.
+            server.update(ReloadState) { ReloadState.Reloading() }
+            server.update(ReloadState) { ReloadState.Failed(reason = "Incompatible change") }
+
+            val result = client.callTool("await_reload", mapOf("timeout_seconds" to 10))
+            assertEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains("Incompatible change"), "unexpected error message: $text")
+        }
+    }
+
+    @Test
+    fun `test - reload in auto mode reports still reloading on timeout`() = runTest(timeout = 20.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+
+            // A build is in progress and never settles within the timeout.
+            server.update(ReloadState) { ReloadState.Reloading() }
+
+            val result = client.callTool("await_reload", mapOf("timeout_seconds" to 1))
+            assertNotEquals(true, result.isError)
+            val text = (result.content.first() as TextContent).text
+            assertTrue(text.contains(""""status":"reloading""""), "unexpected result: $text")
+        }
+    }
+
     @Test
     fun `test - status shows failed when ReloadState is Failed`() = runTest(timeout = 10.seconds) {
         val server = startOrchestrationServer()
@@ -1130,7 +1263,7 @@ class McpServerTest {
             server.update(ReloadCountState) { ReloadCountState(it.successfulReloads, it.failedReloads + 1) }
             val text = awaitStatus(client, """"reloadState":"failed"""")
             assertEquals(
-                """{"connected":true,"reloadState":"failed","lastError":"Compilation error","successfulReloads":0,"failedReloads":1}""",
+                """{"connected":true,"buildContinuous":false,"reloadState":"failed","lastError":"Compilation error","successfulReloads":0,"failedReloads":1}""",
                 text,
             )
         }
@@ -1375,11 +1508,8 @@ class McpServerTest {
 
     @Test
     fun `test - get_logs returns error when disconnected`() = runTest(timeout = 10.seconds) {
-        val logFile = createTempFile("chr", ".log")
-        logFile.writeText("line 1\nline 2")
-
         val orchestration = MutableStateFlow<OrchestrationHandle?>(null)
-        val client = createMcpClient(orchestration, logFile = logFile)
+        val client = createMcpClient(orchestration, pidFile = pidFileWithLogs("line 1\nline 2"))
 
         val result = client.callTool("get_logs", emptyMap())
         assertEquals(true, result.isError)
@@ -1395,7 +1525,7 @@ class McpServerTest {
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
             val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
-            // Use the default logFile, which points at a non-existent file.
+            // Use the default pidFile, whose associated log file does not exist.
             val client = createMcpClient(orchestration)
 
             val result = client.callTool("get_logs", emptyMap())
@@ -1407,16 +1537,13 @@ class McpServerTest {
 
     @Test
     fun `test - get_logs returns all lines by default`() = runTest(timeout = 10.seconds) {
-        val logFile = createTempFile("chr", ".log")
-        logFile.writeText("line 1\nline 2\nline 3")
-
         val server = startOrchestrationServer()
         server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
             val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
-            val client = createMcpClient(orchestration, logFile = logFile)
+            val client = createMcpClient(orchestration, pidFile = pidFileWithLogs("line 1\nline 2\nline 3"))
 
             val result = client.callTool("get_logs", emptyMap())
             assertNotEquals(true, result.isError)
@@ -1427,16 +1554,16 @@ class McpServerTest {
 
     @Test
     fun `test - get_logs honors the limit parameter`() = runTest(timeout = 10.seconds) {
-        val logFile = createTempFile("chr", ".log")
-        logFile.writeText((1..10).joinToString("\n") { "line $it" })
-
         val server = startOrchestrationServer()
         server.use {
             val port = server.port.awaitOrThrow()
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
             val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
-            val client = createMcpClient(orchestration, logFile = logFile)
+            val client = createMcpClient(
+                orchestration,
+                pidFile = pidFileWithLogs((1..10).joinToString("\n") { "line $it" }),
+            )
 
             val result = client.callTool("get_logs", mapOf("limit" to 3))
             assertNotEquals(true, result.isError)
@@ -1448,9 +1575,7 @@ class McpServerTest {
 
     @Test
     fun `test - get_logs returns everything when limit is zero`() = runTest(timeout = 10.seconds) {
-        val logFile = createTempFile("chr", ".log")
         val expected = (1..500).joinToString("\n") { "line $it" }
-        logFile.writeText(expected)
 
         val server = startOrchestrationServer()
         server.use {
@@ -1458,7 +1583,7 @@ class McpServerTest {
             val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
 
             val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
-            val client = createMcpClient(orchestration, logFile = logFile)
+            val client = createMcpClient(orchestration, pidFile = pidFileWithLogs(expected))
 
             val result = client.callTool("get_logs", mapOf("limit" to 0))
             assertNotEquals(true, result.isError)


### PR DESCRIPTION
Waits for the reload to finish. Asks the client to poll the status on timeout. 
May/should be called for `--auto` mode.