### PR TITLE
[mcpserver] CMP-10329: Add save_to parameter to take_screenshot tool

### DIFF
--- a/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
+++ b/hot-reload-mcp/src/main/kotlin/org/jetbrains/compose/reload/mcp/McpServer.kt
@@ -71,7 +71,9 @@ import java.io.OutputStream
 import java.nio.file.Path
 import java.util.Base64
 import kotlin.io.path.bufferedReader
+import kotlin.io.path.createParentDirectories
 import kotlin.io.path.isRegularFile
+import kotlin.io.path.writeBytes
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -116,6 +118,9 @@ private val RestartTimeoutParam = Property("timeout_seconds", "integer",
         "restart request (default $DEFAULT_RESTART_TIMEOUT_SECONDS). Keep this at or below your own " +
         "tool-call timeout; if it expires the tool returns 'reconnected':false and you should poll the " +
         "'status' tool until 'connected' is true again.")
+private val SaveToParam = Property("save_to", "string",
+    description = "Absolute path where the screenshot image should be saved on disk. " +
+        "When omitted the screenshot is only returned as inline image data.")
 
 /** Builds a [ToolSchema] from [properties]; by default all of them are required. */
 private fun toolSchema(
@@ -222,7 +227,7 @@ internal suspend fun startMcpServer(
             name = "take_screenshot",
             description = "Take a screenshot of the running Compose application window. " +
                 "Use the 'status' tool first to check if the application is connected.",
-            inputSchema = toolSchema(WindowIdParam, required = emptyList())
+            inputSchema = toolSchema(WindowIdParam, SaveToParam, required = emptyList())
         ) { request ->
             handleTakeScreenshot(orchestration, request)
         }
@@ -632,6 +637,8 @@ private suspend fun handleTakeScreenshot(
     orchestration: StateFlow<OrchestrationHandle?>,
     request: CallToolRequest,
 ): CallToolResult = withWindow(orchestration, "take_screenshot", request.arguments) { handle, resolvedId ->
+    val saveTo = (request.arguments?.get(SaveToParam.name) as? JsonPrimitive)?.contentOrNull
+        ?.let { Path.of(it) }
     try {
         val screenshotRequest = ScreenshotRequest(windowId = resolvedId)
         logger.info { "take_screenshot: sending request '${screenshotRequest.messageId}'" }
@@ -649,8 +656,17 @@ private suspend fun handleTakeScreenshot(
             }
             else -> {
                 logger.debug { "take_screenshot: received ${screenshot.data.size} bytes (${screenshot.format})" }
-                val base64 = Base64.getEncoder().encodeToString(screenshot.data)
-                CallToolResult(content = listOf(ImageContent(data = base64, mimeType = "image/${screenshot.format}")))
+                val content = buildList {
+                    if (saveTo != null) {
+                        saveTo.createParentDirectories()
+                        saveTo.writeBytes(screenshot.data)
+                        logger.info { "take_screenshot: saved to '$saveTo'" }
+                        add(TextContent("Screenshot saved to: $saveTo"))
+                    }
+                    val base64 = Base64.getEncoder().encodeToString(screenshot.data)
+                    add(ImageContent(data = base64, mimeType = "image/${screenshot.format}"))
+                }
+                CallToolResult(content = content)
             }
         }
     } catch (e: Exception) {

--- a/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
+++ b/hot-reload-mcp/src/test/kotlin/org/jetbrains/compose/reload/mcp/McpServerTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,9 +59,12 @@ import java.io.PipedOutputStream
 import java.nio.file.Path
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.createTempFile
+import kotlin.io.path.exists
+import kotlin.io.path.readBytes
 import kotlin.io.path.writeText
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -833,6 +837,43 @@ class McpServerTest {
             assertEquals(true, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("Window 'ghost' not found"), "unexpected error message: $text")
+        }
+    }
+
+    @Test
+    fun `test - take_screenshot saves image to disk and still returns it`() = runTest(timeout = 10.seconds) {
+        val server = startOrchestrationServer()
+        server.use {
+            val port = server.port.awaitOrThrow()
+            val toolingClient = connectOrchestrationClient(OrchestrationClientRole.Tooling, port).getOrThrow()
+
+            val imageBytes = ByteArray(8) { it.toByte() }
+            launch {
+                val request = server.asFlow().filterIsInstance<ScreenshotRequest>().first()
+                server.send(ScreenshotResult(
+                    screenshotRequestId = request.messageId,
+                    format = "png",
+                    data = imageBytes,
+                ))
+            }
+
+            val orchestration = MutableStateFlow<OrchestrationHandle?>(toolingClient)
+            val client = createMcpClient(orchestration)
+            registerSingleWindow(server, client)
+
+            // A nested path also exercises automatic creation of missing parent directories.
+            val target = createTempDirectory().resolve("nested/dir/screenshot.png")
+            val result = client.callTool("take_screenshot", mapOf("save_to" to target.toString()))
+            assertNotEquals(true, result.isError)
+
+            // The file is written with the raw image bytes.
+            assertTrue(target.exists(), "expected screenshot file to be written")
+            assertContentEquals(imageBytes, target.readBytes())
+
+            // The result reports the save and still includes the inline image.
+            val saveMessage = result.content.filterIsInstance<TextContent>().first().text
+            assertTrue(saveMessage.contains(target.toString()), "unexpected save message: $saveMessage")
+            assertTrue(result.content.any { it is ImageContent }, "expected inline image content")
         }
     }
 


### PR DESCRIPTION
Allows the tool to save screenshot image bytes to disk.

Fixes: [CMP-10329](https://youtrack.jetbrains.com/issue/CMP-10329)