### PR TITLE
[devtools] Fix reload state hanging indefinitely in continuous/auto mode

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompilerExtension.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/gradle/GradleRecompilerExtension.kt
@@ -42,7 +42,7 @@ internal class GradleRecompilerExtension : RecompilerExtension {
         }
 
         /* Side Effect */
-        if (HotReloadEnvironment.gradleWarmupEnabled || HotReloadEnvironment.gradleBuildContinuous) {
+        if (HotReloadEnvironment.gradleWarmupEnabled) {
             OrchestrationMessage.RecompileRequest().sendAsync()
         }
 

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/recompiler.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/recompiler.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import org.jetbrains.compose.devtools.api.RecompilerExtension
 import org.jetbrains.compose.reload.core.Environment
+import org.jetbrains.compose.reload.core.ExitCode
 import org.jetbrains.compose.reload.core.Future
+import org.jetbrains.compose.reload.core.HotReloadEnvironment
 import org.jetbrains.compose.reload.core.Try
 import org.jetbrains.compose.reload.core.WorkerThread
 import org.jetbrains.compose.reload.core.createLogger
@@ -20,11 +22,11 @@ import org.jetbrains.compose.reload.core.debug
 import org.jetbrains.compose.reload.core.dispatcher
 import org.jetbrains.compose.reload.core.error
 import org.jetbrains.compose.reload.core.exception
+import org.jetbrains.compose.reload.core.getOrNull
 import org.jetbrains.compose.reload.core.info
 import org.jetbrains.compose.reload.core.invokeOnError
 import org.jetbrains.compose.reload.core.invokeOnFinish
 import org.jetbrains.compose.reload.core.isFailure
-import org.jetbrains.compose.reload.core.isSuccess
 import org.jetbrains.compose.reload.core.launchTask
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RecompileRequest
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.RecompileResult
@@ -57,38 +59,43 @@ internal fun launchRecompiler(): Future<Unit> = launchTask("Recompiler", recompi
     }
 
     logger.debug("Recompiler created: '${recompiler.name}'")
-    messages.consumeAsFlow().filterIsInstance<RecompileRequest>().conflateAsList()
-        .collect recompile@{ pendingRequests ->
-            logger.info("Running '${recompiler.name}'...")
 
-            /*
-            Collect all accumulated pending requests
-             */
-            val context = RecompilerContextImpl(
-                logger = createLogger(name = recompiler.name, environment = Environment.build),
-                requests = pendingRequests, orchestration = orchestration
-            )
+    suspend fun runBuild(requests: List<RecompileRequest>): Try<ExitCode?> {
+        logger.info("Running '${recompiler.name}'...")
+        val context = RecompilerContextImpl(
+            logger = createLogger(name = recompiler.name, environment = Environment.build),
+            requests = requests, orchestration = orchestration
+        )
 
-            val exitCode = Try {
-                withDisposableShutdownHook(context) {
-                    useDisposableStoppable(context) {
-                        recompiler.buildAndReload(context)
-                    }
-                }
-            }
-
-            if (exitCode.isFailure()) {
-                logger.error("BuildSystem: '${recompiler.name}' failed", exitCode.exception)
-                pendingRequests.forEach { request ->
-                    RecompileResult(request.messageId, null).send()
-                }
-            }
-
-            if (exitCode.isSuccess()) {
-                logger.debug("BuildSystem: '${recompiler.name}' finished w/ exitCode=${exitCode}")
-                pendingRequests.forEach { request ->
-                    RecompileResult(request.messageId, exitCode.value?.code).send()
+        val exitCode = Try {
+            withDisposableShutdownHook(context) {
+                useDisposableStoppable(context) {
+                    recompiler.buildAndReload(context)
                 }
             }
         }
+
+        if (exitCode.isFailure()) logger.error("BuildSystem: '${recompiler.name}' failed", exitCode.exception)
+        else logger.debug("BuildSystem: '${recompiler.name}' finished w/ exitCode=${exitCode}")
+        return exitCode
+    }
+
+    val requests = messages.consumeAsFlow().filterIsInstance<RecompileRequest>()
+
+    if (HotReloadEnvironment.gradleBuildContinuous) {
+        // Continuous/auto mode: 'buildAndReload' launches a daemon that watches the build inputs and
+        // recompiles/reloads on its own, it never returns until shutdown. So we run it once and respond with
+        // an immediate result on any recompile request.
+        subtask("${recompiler.name} (continuous)", recompilerThread.dispatcher) { runBuild(emptyList()) }
+        requests.collect { request -> RecompileResult(request.messageId, 0).send() }
+    } else {
+        // Non-continuous mode: each (batch of) request triggers one build that compiles, reloads if
+        // needed, and exits. We wait for that build and report its exit code back to every request.
+        requests.conflateAsList().collect { pendingRequests ->
+            val exitCode = runBuild(pendingRequests)
+            pendingRequests.forEach { request ->
+                RecompileResult(request.messageId, exitCode.getOrNull()?.code).send()
+            }
+        }
+    }
 }

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/reloadStateActor.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/reloadStateActor.kt
@@ -98,7 +98,10 @@ fun CoroutineScope.launchReloadStateActor(
         }
 
         if (message is OrchestrationMessage.BuildFinished ||
-            (message is LogMessage && message.message.contains("BUILD SUCCESSFUL"))
+            (message is LogMessage && message.message.contains("BUILD SUCCESSFUL")) ||
+            // In continuous/auto mode a 'RecompileRequest' does not start a build,
+            // so the recompiler answers it immediately with a 'RecompileResult'.
+            (message is OrchestrationMessage.RecompileResult)
         ) update { state ->
             if (state !is ReloadState.Reloading) return@update state
             if (state.reloadRequestId == null) return@update ReloadState.Ok()


### PR DESCRIPTION
In continuous `--auto` mode 'buildAndReload' launches a long-lived Gradle daemon
that never returns, blocking the recompiler loop so RecompileRequests were
never answered and ReloadState stayed 'Reloading' forever.

Run the continuous build once in a background subtask and respond each
RecompileRequest immediately.

Fixes: [CMP-10309](https://youtrack.jetbrains.com/issue/CMP-10309)