### PR TITLE
[docs] Document await_reload tool in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ layer and exposes the following tools:
 
 | Tool | Description                                                 |
 |------|-------------------------------------------------------------|
-| `status` | Checks whether a Compose application is currently connected. When connected, also reports reload state, last error (with optional `lastErrorDetails`), counts of successful/failed reloads, and any windows currently failing to render (`uiErrorWindows`) |
+| `status` | Checks whether a Compose application is currently connected. When connected, also reports the build mode (`buildContinuous`: `true` for `--auto`, `false` for explicit), reload state, last error (with optional `lastErrorDetails`), counts of successful/failed reloads, and any windows currently failing to render (`uiErrorWindows`). Use `buildContinuous` to choose between `reload` and `await_reload` |
 | `reload` | Recompiles the project and hot-reloads the changed classes into the running application. Reports whether classes were reloaded, or `{"status": "reloading"}` when it does not finish within the optional `timeout_seconds` (default 60) — in that case, poll `status` until `reloadState` is no longer `reloading` |
+| `await_reload` | Waits for an autonomous hot reload when the application was started with continuous build mode (`--auto`). Returns `{"success": true}` once the application is in a healthy reloaded state, or `{"status": "reloading"}` when the reload does not finish within the optional `timeout_seconds` (default 60) — in that case, poll `status` until `reloadState` is no longer `reloading` |
 | `list_windows` | Lists registered application windows as a JSON array (`id`, `title`, `x`, `y`, `width`, `height`) |
 | `get_ui_error` | Returns the runtime UI exception currently thrown while a window renders its UI (e.g. an exception in a `@Composable`). Reports `hasError`, and when true, the `message` and `stacktrace` lines |
 | `get_logs` | Returns the most recent log lines from the running Compose application as plain text (oldest first). The `limit` parameter caps the number of lines (default 200; 0 returns all) |
@@ -258,9 +259,9 @@ layer and exposes the following tools:
 
 #### Targeting a specific window
 
-Every tool except `status`, `reload`, `list_windows`, `get_logs`, `restart`, and `reset_ui` accepts an
-optional `window_id` parameter and follows the same window-selection rules. An agent may use
-`list_windows` to discover the available IDs.
+The following tools accept an optional `window_id` parameter: `take_screenshot`, `get_semantic_tree`, `click`, 
+`long_click`, `type_text`, `scroll`, `scroll_to_index`, `resize_window`, and `get_ui_error`.
+All window-targeting tools follow the same window-selection rules. An agent may use `list_windows` to discover the available IDs.
 
 - **`window_id` provided** — the tool operates on that specific window.
 - **`window_id` omitted** — the tool operates on the *first registered window*, that is, the first window


### PR DESCRIPTION
 - Add `await_reload` tool to MCP server tools table with description for `--auto` mode                                                                                                                                               
 - Enumerate tools that accept `window_id` parameter (positive approach) instead of listing exceptions