### PR TITLE
[devtools] Refresh error overlay and notification when the error changes after reload

### DIFF
--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/errorOverlay/DevToolingErrorOverlay.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/errorOverlay/DevToolingErrorOverlay.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,9 +35,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
-import io.sellmair.evas.compose.composeFlow
+import io.sellmair.evas.compose.composeValue
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.map
 import org.jetbrains.compose.devtools.Tag
 import org.jetbrains.compose.devtools.sendAsync
 import org.jetbrains.compose.devtools.sidecar.DtConsole
@@ -62,12 +60,10 @@ import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.ShutdownR
 
 @Composable
 internal fun DevToolingErrorOverlay(windowId: WindowId, windowState: WindowState) {
-    val uiExceptionState by ErrorUIState.composeFlow()
-        .map { value -> value.errors[windowId] }
-        .collectAsState(initial = null)
+    val uiExceptionState = ErrorUIState.composeValue().errors[windowId]
 
     uiExceptionState?.let { error ->
-        var showWindow by remember { mutableStateOf(true) }
+        var showWindow by remember(error) { mutableStateOf(true) }
         if (!showWindow) return@let
 
         Window(

--- a/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/NotificationsUIState.kt
+++ b/hot-reload-devtools/src/main/kotlin/org/jetbrains/compose/devtools/states/NotificationsUIState.kt
@@ -96,10 +96,24 @@ fun CoroutineScope.launchNotificationsUIState() = launchState(NotificationsUISta
 
         ErrorUIState.collect { errors ->
             for ((windowId, error) in errors.errors) {
-                if (windowId !in notifiedErrors) {
-                    val notification = error.toNotification()
-                    notifiedErrors[windowId] = error to notification
-                    NotificationsUIState.update { it + notification }
+                val existing = notifiedErrors[windowId]
+                when {
+                    existing == null -> {
+                        val notification = error.toNotification()
+                        notifiedErrors[windowId] = error to notification
+                        NotificationsUIState.update { it + notification }
+                    }
+                    // The error for this window changed (a different exception after a reload):
+                    // update the existing notification.
+                    existing.first != error -> {
+                        val updated = existing.second.copy(
+                            title = error.title,
+                            message = error.message.orEmpty(),
+                            details = error.stacktrace,
+                        )
+                        notifiedErrors[windowId] = error to updated
+                        NotificationsUIState.update { it.replace(updated) }
+                    }
                 }
             }
 

--- a/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/state/NotificationsUIStateTest.kt
+++ b/hot-reload-devtools/src/test/kotlin/org/jetbrains/compose/devtools/tests/state/NotificationsUIStateTest.kt
@@ -105,6 +105,39 @@ class NotificationsUIStateTest {
         awaitNotifications { it.notifications.isEmpty() }
     }
 
+    @Test
+    fun `ui error notification is updated in place when the error changes`() = runNotificationsTest {
+        val windowId = WindowId("")
+        awaitNotifications { it.notifications.isEmpty() }
+
+        val first = UIErrorDescription("UI Exception", "first", listOf("at Foo.kt:1"))
+        ErrorUIState.update { it.copy(errors = it.errors + (windowId to first)) }
+        reloadMainThread.awaitIdle()
+        testScheduler.advanceUntilIdle()
+        awaitNotifications { it.notifications.size == 1 }
+
+        val firstNotification = currentNotifications().single()
+        assertEquals("first", firstNotification.message)
+        assertEquals(listOf("at Foo.kt:1"), firstNotification.details)
+
+        // The error for the same window changes -- existing notification must be updated
+        val second = UIErrorDescription("UI Exception", "second", listOf("at Bar.kt:2"))
+        ErrorUIState.update { it.copy(errors = it.errors + (windowId to second)) }
+        reloadMainThread.awaitIdle()
+        testScheduler.advanceUntilIdle()
+        awaitNotifications { it.notifications.singleOrNull()?.message == "second" }
+
+        val updated = currentNotifications().single()
+        assertEquals(firstNotification.id, updated.id) // same notification, updated in place
+        assertEquals("second", updated.message)
+        assertEquals(listOf("at Bar.kt:2"), updated.details)
+
+        ErrorUIState.update { it.copy(errors = it.errors - windowId) }
+        reloadMainThread.awaitIdle()
+        testScheduler.advanceUntilIdle()
+        awaitNotifications { it.notifications.isEmpty() }
+    }
+
     private fun runNotificationsTest(
         testBody: suspend TestScope.() -> Unit
     ) = runTest(States() + Events()) {


### PR DESCRIPTION
The error overlay and its notification were shown once per window and never refreshed, so a reload that produced a different error for the same window left the stale error on screen. NotificationsUIState now updates the existing notification when a window's error changes, and DevToolingErrorOverlay is keyed on the error so a new/changed error re-shows the overlay.

Adds a NotificationsUIStateTest case asserting the notification is updated when a window's error changes.