### PR TITLE
[runtime] Detect subcomposition errors via the Recomposer error-state API

### DIFF
--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/DevelopmentEntryPoint.kt
@@ -26,7 +26,6 @@ import org.jetbrains.compose.devtools.api.UIErrorState
 import org.jetbrains.compose.reload.InternalHotReloadApi
 import org.jetbrains.compose.reload.agent.orchestration
 import org.jetbrains.compose.reload.agent.sendAsync
-import org.jetbrains.compose.reload.agent.sendBlocking
 import org.jetbrains.compose.reload.core.HotReloadEnvironment.reloadEffectsEnabled
 import org.jetbrains.compose.reload.core.WindowId
 import org.jetbrains.compose.reload.core.createLogger
@@ -79,6 +78,28 @@ public fun DevelopmentEntryPoint(
         }
     }
 
+    // CMP-10248: use error state API to detect UI errors for Compose 1.11+.
+    // Use runCatching() workaround below for older Compose.
+    if (isRecomposerErrorStateApiAvailable) LaunchedEffect(windowId) {
+        var reported: Throwable? = null
+        recomposerErrors().collect { error ->
+            when {
+                // A new error detected by the recomposer
+                error != null && error !== reported -> {
+                    logger.error("UI exception:", error)
+                    reported = error
+                    publishUIError(windowId, error)
+                }
+
+                // The recomposer recovered: clear the overlay
+                error == null && reported != null -> {
+                    unpublishUIError(windowId)
+                    reported = null
+                }
+            }
+        }
+    }
+
     if (window != null) {
         handleWindowRequests<ScreenshotRequest>(windowId, { it.windowId }) { handleScreenshotRequest(it, window, windowId) }
         handleWindowRequests<SemanticTreeRequest>(windowId, { it.windowId }) { handleSemanticTreeRequest(it, window, windowId) }
@@ -99,27 +120,14 @@ public fun DevelopmentEntryPoint(
             }
         }.onFailure { exception ->
             logger.error("Failed invoking 'JvmDevelopmentEntryPoint':", exception)
-            hotReloadState.update { state -> state.copy(uiError = exception) }
-            UIException(
-                windowId = windowId,
-                message = exception.message,
-                stacktrace = exception.stackTrace.toList()
-            ).sendBlocking()
-            if (windowId != null) updateUIErrorState { errors ->
-                errors + (windowId to UIErrorState.UIError(
-                    message = exception.message,
-                    stacktrace = exception.stackTrace.map { it.toString() },
-                ))
-            }
-
+            if (!isRecomposerErrorStateApiAvailable) publishUIError(windowId, exception)
         }.onSuccess {
-            hotReloadState.update { state -> state.copy(uiError = null) }
+            if (!isRecomposerErrorStateApiAvailable) unpublishUIError(windowId)
             UIRendered(
                 windowId = windowId,
                 reloadRequestId = currentHotReloadState.reloadRequestId,
                 currentHotReloadState.iteration
             ).sendAsync()
-            if (windowId != null) updateUIErrorState { errors -> errors - windowId }
         }.getOrThrow()
     }
 
@@ -147,6 +155,29 @@ private inline fun <reified T : OrchestrationMessage> handleWindowRequests(
             .filter { request -> windowIdOf(request) == null || windowIdOf(request) == windowId }
             .collect { request -> respond(request).sendAsync() }
     }
+}
+
+/**
+ * Publishes [exception] to the devtools error overlay (the per-window [UIErrorState]) and broadcasts a
+ * [UIException] so the devtools error overlay can show its stack trace.
+ */
+private fun publishUIError(windowId: WindowId?, exception: Throwable) {
+    if (windowId != null) updateUIErrorState { errors ->
+        errors + (windowId to UIErrorState.UIError(
+            message = exception.message,
+            stacktrace = exception.stackTrace.map { it.toString() },
+        ))
+    }
+    UIException(
+        windowId = windowId,
+        message = exception.message,
+        stacktrace = exception.stackTrace.toList()
+    ).sendAsync()
+}
+
+/** Removes the [windowId] entry from the overlay ([UIErrorState]). */
+private fun unpublishUIError(windowId: WindowId?) {
+    if (windowId != null) updateUIErrorState { errors -> errors - windowId }
 }
 
 private fun updateUIErrorState(

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/HotReloadState.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/HotReloadState.kt
@@ -16,7 +16,6 @@ internal data class HotReloadState(
     val reloadRequestId: OrchestrationMessageId? = null,
     val iteration: Int,
     val reloadError: Throwable? = null,
-    val uiError: Throwable? = null,
     val key: Int = 0,
 ) {
     override fun toString(): String {
@@ -25,7 +24,6 @@ internal data class HotReloadState(
             append("iteration=$iteration, ")
             append("key=$key, ")
             if (reloadError != null) append("error=${reloadError.message}, ")
-            if (uiError != null) append("uiError=${uiError.message}, ")
             append(" }")
         }
     }
@@ -40,7 +38,6 @@ internal val hotReloadState: MutableStateFlow<HotReloadState> = MutableStateFlow
                 reloadRequestId = reloadRequestId,
                 iteration = state.iteration + 1,
                 reloadError = result.exceptionOrNull(),
-                key = state.key + if (state.uiError != null) 1 else 0,
             )
         }
     }

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/recomposerErrors.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/recomposerErrors.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 JetBrains s.r.o. and Compose Hot Reload contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.compose.reload.jvm
+
+import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.RecomposerInfo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import org.jetbrains.compose.reload.core.createLogger
+import org.jetbrains.compose.reload.core.error
+
+private val logger = createLogger()
+
+/**
+ * Whether the `RecomposerInfo.errorState` tooling API (introduced in Compose 1.11) is present.
+ */
+internal val isRecomposerErrorStateApiAvailable: Boolean by lazy {
+    try {
+        RecomposerInfo::class.java.getMethod("getErrorState")
+        true
+    } catch (_: Throwable) {
+        false
+    }
+}
+
+/**
+ * Emits the most recent composition error captured by any running [Recomposer], or `null` while no
+ * recomposer is currently in an error state.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun recomposerErrors(): Flow<Throwable?> =
+    Recomposer.runningRecomposers.flatMapLatest { recomposers ->
+        val errorStates = recomposers.mapNotNull { recomposer -> recomposer.errorStateOrNull() }
+        if (errorStates.isEmpty()) flowOf(null)
+        else combine(errorStates) { errors -> errors.firstNotNullOfOrNull { it } }
+    }
+
+/**
+ * Reflectively accesses [RecomposerInfo.errorState], mapping every emitted error information to its
+ * [Throwable] cause. Returns `null` when the API is not available (Compose older than 1.11).
+ */
+private fun RecomposerInfo.errorStateOrNull(): Flow<Throwable?>? {
+    val getErrorState = try {
+        javaClass.getMethod("getErrorState").apply { isAccessible = true }
+    } catch (_: NoSuchMethodException) {
+        return null
+    } catch (t: Throwable) {
+        logger.error("Failed to access 'RecomposerInfo.errorState'", t)
+        return null
+    }
+
+    val errorState = try {
+        @Suppress("UNCHECKED_CAST")
+        getErrorState.invoke(this) as StateFlow<Any?>
+    } catch (t: Throwable) {
+        logger.error("Failed to read 'RecomposerInfo.errorState'", t)
+        return null
+    }
+
+    return errorState.map { errorInformation -> errorInformation?.causeOrNull() }
+}
+
+/** Reflectively reads `RecomposerErrorInformation.cause`. */
+private fun Any.causeOrNull(): Throwable? = try {
+    javaClass.getMethod("getCause").apply { isAccessible = true }.invoke(this) as? Throwable
+} catch (t: Throwable) {
+    logger.error("Failed to access 'RecomposerErrorInformation.cause'", t)
+    null
+}

--- a/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/ErrorRecoveryTests.kt
+++ b/tests/src/reloadFunctionalTest/kotlin/org/jetbrains/compose/reload/tests/ErrorRecoveryTests.kt
@@ -8,6 +8,7 @@ package org.jetbrains.compose.reload.tests
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
 import org.jetbrains.compose.reload.test.gradle.HotReloadTest
 import org.jetbrains.compose.reload.test.gradle.HotReloadTestFixture
+import org.jetbrains.compose.reload.test.gradle.MinComposeVersion
 import org.jetbrains.compose.reload.test.gradle.checkScreenshot
 import org.jetbrains.compose.reload.test.gradle.initialSourceCode
 import org.jetbrains.compose.reload.test.gradle.replaceText
@@ -45,6 +46,47 @@ class ErrorRecoveryTests {
             code.replaceText("""error("Foo")""", """TestText("Recovered")""")
             requestAndAwaitReload()
             fixture.checkScreenshot("1-recovered")
+        }
+    }
+
+    /**
+     * Regression test for CMP-10248: an exception thrown while *recomposing* the content of a
+     * subcomposition (here a [androidx.compose.foundation.layout.BoxWithConstraints], composed in a
+     * separate child composition) is captured by the Compose `Recomposer`'s error state. It must result into
+     * [OrchestrationMessage.UIException] so the error overlay shows it instead of staying hidden in the logs.
+     */
+    @HotReloadTest
+    @QuickTest
+    @MinComposeVersion("1.11.0")
+    fun `subcomposition error is reported as UIException`(fixture: HotReloadTestFixture) = fixture.runTest {
+        fixture.initialSourceCode(
+            """
+            import androidx.compose.foundation.layout.BoxWithConstraints
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.State
+            import androidx.compose.runtime.mutableStateOf
+            import androidx.compose.runtime.remember
+            import org.jetbrains.compose.reload.test.*
+
+            @Composable
+            fun Failing(fail: State<Boolean>) {
+                BoxWithConstraints {
+                    if (fail.value) error("Foo") else TestText("Hello")
+                }
+            }
+
+            fun main() {
+                screenshotTestApplication {
+                    val fail = remember { mutableStateOf(false) }
+                    onTestEvent { fail.value = true }
+                    Failing(fail)
+                }
+            }
+        """.trimIndent()
+        )
+
+        fixture.sendTestEvent {
+            assertEquals("Foo", skipToMessage<OrchestrationMessage.UIException>().message)
         }
     }
 


### PR DESCRIPTION
Exceptions thrown while recomposing a subcomposition (e.g. the content of a `SubcomposeLayout` / `BoxWithConstraints`) are captured by the Compose Recomposer and not rethrown into `DevelopmentEntryPoint`'s `runCatching`, so until now they only appeared in the logs — never in the devtools error overlay.

Also removed `HotReloadState.uiError`. Its only purpose was to force a fresh recomposition after a main-composition error. Testing showed the composition successfully recovers from such an error so the field and the key bump (force clean ui) are dropped.

Fixes: [CMP-10248](https://youtrack.jetbrains.com/issue/CMP-10248)

Test: Added new `subcomposition error is reported as UIException` test  to `ErrorRecoveryTests`, gated to Compose 1.11 where the error-state API introduced. Though all `ErrorRecoveryTests` go via error-state API now because default Compose is 1.11. 
