### PR TITLE
[runtime] Add hard-reset composition recovery under a runtime flag

### DIFF
--- a/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/compose.kt
+++ b/hot-reload-agent/src/main/kotlin/org/jetbrains/compose/reload/agent/compose.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.compose.reload.agent
 
+import org.jetbrains.compose.reload.InternalHotReloadApi
 import org.jetbrains.compose.reload.analysis.ClassId
 import org.jetbrains.compose.reload.analysis.ComposeGroupKey
 import org.jetbrains.compose.reload.analysis.Ids
@@ -16,6 +17,7 @@ import org.jetbrains.compose.reload.core.warn
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.InvalidatedComposeGroupMessage
 import org.jetbrains.compose.reload.orchestration.OrchestrationMessage.InvalidatedComposeGroupMessage.DirtyScope
 import java.lang.instrument.ClassFileTransformer
+import java.lang.reflect.InvocationTargetException
 import java.lang.instrument.Instrumentation
 import java.security.ProtectionDomain
 import java.util.WeakHashMap
@@ -138,3 +140,50 @@ private fun invalidateGroupsWithKey(loader: ClassLoader, key: ComposeGroupKey) {
         .singleOrNull { it.name.contains("invalidateGroupsWithKey") }
         ?.apply { invoke(recomposerCompanion, key.key) }
 }
+
+/**
+ * Forces a full composition teardown and rebuild ("hard" reload).
+ *
+ * Unlike [invalidateGroupsWithKey] — which only invalidates changed groups and, crucially, *skips*
+ * any recomposer whose current error is non-recoverable — this disposes every running recomposer's
+ * compositions and recomposes them from scratch (Compose's 'saveStateAndDisposeForHotReload' followed
+ * by 'loadStateAndComposeForHotReload', which resets all error states).
+ */
+@InternalHotReloadApi
+fun reloadCompositionState() {
+    runOnUiThreadBlocking {
+        composeClassLoadersLock.withLock {
+            composeClassLoaders.keys.forEach { loader -> reloadCompositionState(loader) }
+        }
+    }
+}
+
+private fun reloadCompositionState(loader: ClassLoader) {
+    val recomposerClass = loader.loadClass(Ids.Recomposer.classId.toFqn())
+    val recomposerCompanion = recomposerClass.getField(Ids.Recomposer.companion.fieldName).get(null)
+    val recomposerCompanionClass = loader.loadClass(Ids.Recomposer.Companion.classId.toFqn())
+
+    val save = recomposerCompanionClass.methods
+        .singleOrNull { it.name.contains("saveStateAndDisposeForHotReload") }
+    val load = recomposerCompanionClass.methods
+        .singleOrNull { it.name.contains("loadStateAndComposeForHotReload") }
+
+    if (save == null || load == null) {
+        logger.warn("'saveStateAndDisposeForHotReload'/'loadStateAndComposeForHotReload' not found (${loader.name})")
+        return
+    }
+
+    val token = try {
+        save.invoke(recomposerCompanion)
+    } catch (t: InvocationTargetException) {
+        logger.warn("'saveStateAndDisposeForHotReload' failed", t.cause ?: t)
+        return
+    }
+
+    try {
+        load.invoke(recomposerCompanion, token)
+    } catch (t: InvocationTargetException) {
+        logger.warn("'loadStateAndComposeForHotReload' completed with a trailing error", t.cause ?: t)
+    }
+}
+

--- a/hot-reload-core/api/hot-reload-core.api
+++ b/hot-reload-core/api/hot-reload-core.api
@@ -233,6 +233,7 @@ public final class org/jetbrains/compose/reload/core/FutureKt {
 
 public final class org/jetbrains/compose/reload/core/HotReloadEnvironment {
 	public static final field INSTANCE Lorg/jetbrains/compose/reload/core/HotReloadEnvironment;
+	public final fun getCompositionHardResetEnabled ()Z
 	public final fun getDevToolsDetached ()Z
 	public final fun getDevToolsEnabled ()Z
 	public final fun getDevToolsIsHeadless ()Z
@@ -254,6 +255,7 @@ public final class org/jetbrains/compose/reload/core/HotReloadEnvironment {
 
 public final class org/jetbrains/compose/reload/core/HotReloadProperty : java/lang/Enum {
 	public static final field AutoJetBrainsRuntimeProvisioningEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
+	public static final field CompositionHardResetEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field DevToolsDetached Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field DevToolsEnabled Lorg/jetbrains/compose/reload/core/HotReloadProperty;
 	public static final field DevToolsIsHeadless Lorg/jetbrains/compose/reload/core/HotReloadProperty;

--- a/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/resetComposition.kt
+++ b/hot-reload-runtime-jvm/src/main/kotlin/org/jetbrains/compose/reload/jvm/resetComposition.kt
@@ -6,7 +6,26 @@
 package org.jetbrains.compose.reload.jvm
 
 import kotlinx.coroutines.flow.update
+import org.jetbrains.compose.reload.agent.reloadCompositionState
+import org.jetbrains.compose.reload.core.HotReloadEnvironment
 
+/**
+ * Resets the current composition in response to an explicit request (e.g. a 'CleanCompositionRequest'
+ * or 'RetryFailedCompositionRequest').
+ *
+ * The strategy is selected by [HotReloadEnvironment.compositionHardResetEnabled]:
+ *  - hard reset: a full teardown+rebuild via Compose's hot-reload state
+ *    save/load ('reloadCompositionState'), which resets error states and
+ *    recreates the scene/window. Required on Compose runtimes that cannot recover from
+ *    a subcomposition error (See CMP-10459, CMP-10471).
+ *  - light reset: bump 'hotReloadState.key', which only disposes and recomposes the entry point's
+ *    subtree — no window recreation. Sufficient when Compose runtime can recover
+ *    from subcomposition errors.
+ */
 internal fun resetComposition() {
-    hotReloadState.update { state -> state.copy(key = state.key + 1) }
+    if (HotReloadEnvironment.compositionHardResetEnabled) {
+        reloadCompositionState()
+    } else {
+        hotReloadState.update { state -> state.copy(key = state.key + 1) }
+    }
 }

--- a/properties.yaml
+++ b/properties.yaml
@@ -234,6 +234,21 @@ ReloadEffectsEnabled:
   documentation: |
     Enable reload effects that are shown in the UI when a reload is triggered.
 
+CompositionHardResetEnabled:
+  key: compose.reload.compositionHardResetEnabled
+  type: boolean
+  default: "true"
+  target: [ application ]
+  visibility: delicate
+  documentation: |
+    Selects the strategy used by 'Reset UI' button.
+    - true: hard reset - recreates the application window. 
+            So the window blinks but the app recovers from non-consistent/corrupted state 
+            that can happen due to erroneous reloads.  
+    - false: light reset - dispose and recompose the entry point subtree. 
+             The window does not blink but may fail to recover from non-consistent/corrupted state 
+             due to possible bugs in Compose Runtime. 
+
 IntelliJDebuggerDispatchPort:
   key: compose.reload.idea.debugger.dispatch.port
   type: int


### PR DESCRIPTION
Hard reset is required when Compose Runtime cannot recover from corrupted state.
See [CMP-10459](https://youtrack.jetbrains.com/issue/CMP-10459), [CMP-10471](https://youtrack.jetbrains.com/issue/CMP-10471).

Hard-reset is added under a runtime flag. 
Enabled by default because even when the fixes for above bugs are landed to AOSP, we cannot be 100% sure that there won't remain other bugs. Hard-reset is better/faster then restart but has unfortunate side-effect: window blinks because it is also recreated. 